### PR TITLE
Bugfix/serial linux noblock

### DIFF
--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -235,7 +235,7 @@ bool serial_port_read(struct serial_port *port, void *buffer, size_t num_bytes, 
 
         if(local_bytes_read == (ssize_t)-1 && errno != EAGAIN)
             return false;
-        if(local_bytes_read > 0)
+        if(local_bytes_read >= 0)
             *bytes_read = local_bytes_read;
     }
 


### PR DESCRIPTION
Looks like the serial port would block forever on linux if there was no data, this PR uses poll to wait for 10ms, and if there is no data, return early