### PR TITLE
Packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,12 @@ if(BUILD_DOCUMENTATION)
         COMMENT "Generating documentation."
     )
 
+    # Add a target to enable users to zip up the docs
+    add_custom_target(package_docs
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/documentation
+        DEPENDS docs
+        COMMAND ${CMAKE_COMMAND} -E tar "cf" "${CMAKE_CURRENT_BINARY_DIR}/mipsdk_${MIP_GIT_VERSION}_Documentation.zip" --format=zip "."
+    )
 endif(BUILD_DOCUMENTATION)
 
 #
@@ -416,13 +422,4 @@ if(BUILD_PACKAGE)
         DESCRIPTION "MIP SDK static library and header files"
         GROUP mip
     )
-
-    # If building both documentation and packages, zip up the docs
-    if(BUILD_DOCUMENTATION)
-        add_custom_target(package_docs
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/documentation
-            DEPENDS docs
-            COMMAND ${CMAKE_COMMAND} -E tar "cf" "${CMAKE_CURRENT_BINARY_DIR}/mipsdk_${MIP_GIT_VERSION}_Documentation.zip" --format=zip "."
-        )
-    endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following options may be specified when configuring the build with CMake (e.
 * BUILD_DOCUMENTATION_FULL - Builds internal documentation (default disabled).
 * BUILD_DOCUMENTATION_QUIET - Suppress standard doxygen output (default enabled).
 * MSCL_DISABLE_CPP - Ignores .hpp/.cpp files during the build and does not add them to the project.
+* BUILD_PACKAGE - Adds a `package` target to the project that will build a `.deb`, `.rpm`, or `.7z` file containing the library
 
 ### Compilation for Linux
 


### PR DESCRIPTION
* Uses [`CPack`](https://cmake.org/cmake/help/latest/module/CPack.html) to package the library into `.deb`, `.rpm`, or `.7z` packages
* Adds target `package_docs` to zip up documentation