### PR TITLE
Adds descriptor set as a parameter to the callback for registerDataCallback

### DIFF
--- a/examples/watch_imu.cpp
+++ b/examples/watch_imu.cpp
@@ -45,12 +45,12 @@ void handleAccel(void*, const mip::Field& field, mip::Timestamp timestamp)
     }
 }
 
-void handleGyro(void*, const mip::data_sensor::ScaledGyro& data, mip::Timestamp timestamp)
+void handleGyro(void*, uint8_t descriptorSet, const mip::data_sensor::ScaledGyro& data, mip::Timestamp timestamp)
 {
     printf("Gyro Data:  %f, %f, %f\n", data.scaled_gyro[0], data.scaled_gyro[1], data.scaled_gyro[2]);
 }
 
-void handleMag(void*, const mip::data_sensor::ScaledMag& data, mip::Timestamp timestamp)
+void handleMag(void*, uint8_t descriptorSet, const mip::data_sensor::ScaledMag& data, mip::Timestamp timestamp)
 {
     printf("Mag Data:   %f, %f, %f\n", data.scaled_mag[0], data.scaled_mag[1], data.scaled_mag[2]);
 }

--- a/examples/watch_imu.cpp
+++ b/examples/watch_imu.cpp
@@ -45,12 +45,12 @@ void handleAccel(void*, const mip::Field& field, mip::Timestamp timestamp)
     }
 }
 
-void handleGyro(void*, uint8_t descriptorSet, const mip::data_sensor::ScaledGyro& data, mip::Timestamp timestamp)
+void handleGyro(void*, const mip::data_sensor::ScaledGyro& data, mip::Timestamp timestamp)
 {
     printf("Gyro Data:  %f, %f, %f\n", data.scaled_gyro[0], data.scaled_gyro[1], data.scaled_gyro[2]);
 }
 
-void handleMag(void*, uint8_t descriptorSet, const mip::data_sensor::ScaledMag& data, mip::Timestamp timestamp)
+void handleMag(void*, const mip::data_sensor::ScaledMag& data, mip::Timestamp timestamp)
 {
     printf("Mag Data:   %f, %f, %f\n", data.scaled_mag[0], data.scaled_mag[1], data.scaled_mag[2]);
 }

--- a/src/mip/mip_device.hpp
+++ b/src/mip/mip_device.hpp
@@ -226,10 +226,10 @@ public:
     void registerFieldCallback(C::mip_dispatch_handler& handler, uint8_t descriptorSet, uint8_t fieldDescriptor, Object* object);
 
 
-    template<class DataField, void (*Callback)(void*, const DataField&, Timestamp)>
+    template<class DataField, void (*Callback)(void*, uint8_t, const DataField&, Timestamp)>
     void registerDataCallback(C::mip_dispatch_handler& handler, void* userData=nullptr, uint8_t descriptorSet=DataField::DESCRIPTOR_SET);
 
-    template<class DataField, class Object, void (Object::*Callback)(const DataField&, Timestamp)>
+    template<class DataField, class Object, void (Object::*Callback)(uint8_t, const DataField&, Timestamp)>
     void registerDataCallback(C::mip_dispatch_handler& handler, Object* object, uint8_t descriptorSet=DataField::DESCRIPTOR_SET);
 
 
@@ -473,7 +473,7 @@ void DeviceInterface::registerFieldCallback(C::mip_dispatch_handler& handler, ui
 ///
 /// Example usage:
 ///@code{.cpp}
-/// void handle_packet(void* context, const Packet& packet, Timestamp timestamp)
+/// void handle_packet(void* context, uint8_t descriptorSet, const Packet& packet, Timestamp timestamp)
 /// {
 ///   // Use the packet data
 /// }
@@ -490,7 +490,7 @@ void DeviceInterface::registerFieldCallback(C::mip_dispatch_handler& handler, ui
 ///
 ///@endcode
 ///
-template<class DataField, void (*Callback)(void*, const DataField&, Timestamp)>
+template<class DataField, void (*Callback)(void*, uint8_t, const DataField&, Timestamp)>
 void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, void* userData, uint8_t descriptorSet)
 {
     assert(descriptorSet != 0x00);
@@ -508,7 +508,7 @@ void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, voi
         bool ok = Field(*field).extract(data);
         assert(ok); (void)ok;
 
-        Callback(context, data, timestamp);
+        Callback(context, mip_field_descriptor_set(field), data, timestamp);
     };
 
     registerFieldCallback(handler, descriptorSet, DataField::FIELD_DESCRIPTOR, callback, userData);
@@ -535,7 +535,7 @@ void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, voi
 ///@code{.cpp}
 /// class MySystem
 /// {
-///   void handleAccel(const ScaledAccel& accel, Timestamp timestamp)
+///   void handleAccel(uint8_t descriptorSet, const ScaledAccel& accel, Timestamp timestamp)
 ///   {
 ///   }
 ///
@@ -550,7 +550,7 @@ void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, voi
 /// };
 ///@endcode
 ///
-template<class DataField, class Object, void (Object::*Callback)(const DataField&, Timestamp)>
+template<class DataField, class Object, void (Object::*Callback)(uint8_t, const DataField&, Timestamp)>
 void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, Object* object, uint8_t descriptorSet)
 {
     assert(descriptorSet != 0x00);
@@ -569,7 +569,7 @@ void DeviceInterface::registerDataCallback(C::mip_dispatch_handler& handler, Obj
         assert(ok); (void)ok;
 
         Object* obj = static_cast<Object*>(pointer);
-        (obj->*Callback)(data, timestamp);
+        (obj->*Callback)(mip_field_descriptor_set(field), data, timestamp);
     };
 
     registerFieldCallback(handler, descriptorSet, DataField::FIELD_DESCRIPTOR, callback, object);


### PR DESCRIPTION
**NOTE**: This is an interface breaking change

This is useful if (like in the ROS driver) you handle data fields in mostly the same way, but need to store them somewhere different, or do something slightly different based on the descriptor set. For example:

```C++
void MicrostrainPublishers::handleGnssPosLlh(const uint8_t descriptor_set, const mip::data_gnss::PosLlh& pos_llh, mip::Timestamp timestamp)
{
  // Find the right publisher based on the descriptor set
  const size_t index = (descriptor_set == mip::data_gnss::MIP_GNSS1_DATA_DESC_SET) ? 0 : 1;
  const auto& pub = gnss_publishers_[index];  // Vector with a publisher for each GNSS publisher
  
  // Fill out the message and publish (most of the work)
  ...
}
```