### PR TITLE
Generate MIP definitions from branches/field-index@53647.

### DIFF
--- a/src/mip/definitions/commands_base.h
+++ b/src/mip/definitions/commands_base.h
@@ -173,8 +173,8 @@ mip_cmd_result mip_base_get_device_info(struct mip_interface* device, mip_base_d
 
 struct mip_base_get_device_descriptors_response
 {
-    uint8_t descriptors_count;
     uint16_t* descriptors;
+    uint8_t descriptors_count;
     
 };
 typedef struct mip_base_get_device_descriptors_response mip_base_get_device_descriptors_response;
@@ -229,8 +229,8 @@ mip_cmd_result mip_base_resume(struct mip_interface* device);
 
 struct mip_base_get_extended_descriptors_response
 {
-    uint8_t descriptors_count;
     uint16_t* descriptors;
+    uint8_t descriptors_count;
     
 };
 typedef struct mip_base_get_extended_descriptors_response mip_base_get_extended_descriptors_response;

--- a/src/mip/definitions/commands_base.hpp
+++ b/src/mip/definitions/commands_base.hpp
@@ -230,8 +230,8 @@ struct GetDeviceDescriptors
         static const uint8_t DESCRIPTOR_SET = ::mip::commands_base::DESCRIPTOR_SET;
         static const uint8_t FIELD_DESCRIPTOR = ::mip::commands_base::REPLY_DEVICE_DESCRIPTORS;
         
-        uint8_t descriptors_count = 0;
         uint16_t* descriptors = {nullptr};
+        uint8_t descriptors_count = 0;
         
     };
 };
@@ -326,8 +326,8 @@ struct GetExtendedDescriptors
         static const uint8_t DESCRIPTOR_SET = ::mip::commands_base::DESCRIPTOR_SET;
         static const uint8_t FIELD_DESCRIPTOR = ::mip::commands_base::REPLY_GET_EXTENDED_DESCRIPTORS;
         
-        uint8_t descriptors_count = 0;
         uint16_t* descriptors = {nullptr};
+        uint8_t descriptors_count = 0;
         
     };
 };

--- a/src/mip/definitions/data_filter.hpp
+++ b/src/mip/definitions/data_filter.hpp
@@ -247,6 +247,11 @@ struct PositionLlh
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(latitude,longitude,ellipsoid_height,valid_flags);
+    }
+    
     double latitude = 0; ///< [degrees]
     double longitude = 0; ///< [degrees]
     double ellipsoid_height = 0; ///< [meters]
@@ -270,6 +275,11 @@ struct VelocityNed
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_VEL_NED;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(north,east,down,valid_flags);
+    }
     
     float north = 0; ///< [meters/second]
     float east = 0; ///< [meters/second]
@@ -303,6 +313,11 @@ struct AttitudeQuaternion
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(q,valid_flags);
+    }
+    
     float q[4] = {0}; ///< Quaternion elements EQSTART q = (q_w, q_x, q_y, q_z) EQEND
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -335,6 +350,11 @@ struct AttitudeDcm
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(dcm,valid_flags);
+    }
+    
     float dcm[9] = {0}; ///< Matrix elements in row-major order.
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -357,6 +377,11 @@ struct EulerAngles
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ATT_EULER_ANGLES;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(roll,pitch,yaw,valid_flags);
+    }
     
     float roll = 0; ///< [radians]
     float pitch = 0; ///< [radians]
@@ -382,6 +407,11 @@ struct GyroBias
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias,valid_flags);
+    }
+    
     float bias[3] = {0}; ///< (x, y, z) [radians/second]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -404,6 +434,11 @@ struct AccelBias
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias,valid_flags);
+    }
+    
     float bias[3] = {0}; ///< (x, y, z) [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -425,6 +460,11 @@ struct PositionLlhUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_POS_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(north,east,down,valid_flags);
+    }
     
     float north = 0; ///< [meters]
     float east = 0; ///< [meters]
@@ -449,6 +489,11 @@ struct VelocityNedUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_VEL_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(north,east,down,valid_flags);
+    }
     
     float north = 0; ///< [meters/second]
     float east = 0; ///< [meters/second]
@@ -475,6 +520,11 @@ struct EulerAnglesUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(roll,pitch,yaw,valid_flags);
+    }
+    
     float roll = 0; ///< [radians]
     float pitch = 0; ///< [radians]
     float yaw = 0; ///< [radians]
@@ -499,6 +549,11 @@ struct GyroBiasUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias_uncert,valid_flags);
+    }
+    
     float bias_uncert[3] = {0}; ///< (x,y,z) [radians/sec]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -520,6 +575,11 @@ struct AccelBiasUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ACCEL_BIAS_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias_uncert,valid_flags);
+    }
     
     float bias_uncert[3] = {0}; ///< (x,y,z) [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -549,6 +609,11 @@ struct Timestamp
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(tow,week_number,valid_flags);
+    }
+    
     double tow = 0; ///< GPS Time of Week [seconds]
     uint16_t week_number = 0; ///< GPS Week Number since 1980 [weeks]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -571,6 +636,11 @@ struct Status
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_FILTER_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(filter_state,dynamics_mode,status_flags);
+    }
     
     FilterMode filter_state = static_cast<FilterMode>(0); ///< Device-specific filter state.  Please consult the user manual for definition.
     FilterDynamicsMode dynamics_mode = static_cast<FilterDynamicsMode>(0); ///< Device-specific dynamics mode. Please consult the user manual for definition.
@@ -596,6 +666,11 @@ struct LinearAccel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(accel,valid_flags);
+    }
+    
     float accel[3] = {0}; ///< (x,y,z) [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -617,6 +692,11 @@ struct GravityVector
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_GRAVITY_VECTOR;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(gravity,valid_flags);
+    }
     
     float gravity[3] = {0}; ///< (x, y, z) [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -640,6 +720,11 @@ struct CompAccel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(accel,valid_flags);
+    }
+    
     float accel[3] = {0}; ///< (x,y,z) [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -661,6 +746,11 @@ struct CompAngularRate
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_COMPENSATED_ANGULAR_RATE;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(gyro,valid_flags);
+    }
     
     float gyro[3] = {0}; ///< (x, y, z) [radians/second]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -684,6 +774,11 @@ struct QuaternionAttitudeUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(q,valid_flags);
+    }
+    
     float q[4] = {0}; ///< [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -705,6 +800,11 @@ struct Wgs84GravityMag
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_WGS84_GRAVITY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(magnitude,valid_flags);
+    }
     
     float magnitude = 0; ///< [meters/second^2]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -730,6 +830,11 @@ struct HeadingUpdateState
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_HEADING_UPDATE_STATE;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(heading,heading_1sigma,source,valid_flags);
+    }
     
     enum class HeadingSource : uint16_t
     {
@@ -765,6 +870,11 @@ struct MagneticModel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(intensity_north,intensity_east,intensity_down,inclination,declination,valid_flags);
+    }
+    
     float intensity_north = 0; ///< [Gauss]
     float intensity_east = 0; ///< [Gauss]
     float intensity_down = 0; ///< [Gauss]
@@ -791,6 +901,11 @@ struct AccelScaleFactor
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor,valid_flags);
+    }
+    
     float scale_factor[3] = {0}; ///< (x,y,z) [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -812,6 +927,11 @@ struct AccelScaleFactorUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ACCEL_SCALE_FACTOR_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor_uncert,valid_flags);
+    }
     
     float scale_factor_uncert[3] = {0}; ///< (x,y,z) [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -835,6 +955,11 @@ struct GyroScaleFactor
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor,valid_flags);
+    }
+    
     float scale_factor[3] = {0}; ///< (x,y,z) [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -856,6 +981,11 @@ struct GyroScaleFactorUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_GYRO_SCALE_FACTOR_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor_uncert,valid_flags);
+    }
     
     float scale_factor_uncert[3] = {0}; ///< (x,y,z) [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -879,6 +1009,11 @@ struct MagBias
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias,valid_flags);
+    }
+    
     float bias[3] = {0}; ///< (x,y,z) [Gauss]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -900,6 +1035,11 @@ struct MagBiasUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_MAG_BIAS_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias_uncert,valid_flags);
+    }
     
     float bias_uncert[3] = {0}; ///< (x,y,z) [Gauss]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -924,6 +1064,11 @@ struct StandardAtmosphere
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_STANDARD_ATMOSPHERE_DATA;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(geometric_altitude,geopotential_altitude,standard_temperature,standard_pressure,standard_density,valid_flags);
+    }
     
     float geometric_altitude = 0; ///< Input into calculation [meters]
     float geopotential_altitude = 0; ///< [meters]
@@ -955,6 +1100,11 @@ struct PressureAltitude
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(pressure_altitude,valid_flags);
+    }
+    
     float pressure_altitude = 0; ///< [meters]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -975,6 +1125,11 @@ struct DensityAltitude
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_DENSITY_ALTITUDE_DATA;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(density_altitude,valid_flags);
+    }
     
     float density_altitude = 0; ///< m
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1000,6 +1155,11 @@ struct AntennaOffsetCorrection
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(offset,valid_flags);
+    }
+    
     float offset[3] = {0}; ///< (x,y,z) [meters]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1021,6 +1181,11 @@ struct AntennaOffsetCorrectionUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ANTENNA_OFFSET_CORRECTION_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(offset_uncert,valid_flags);
+    }
     
     float offset_uncert[3] = {0}; ///< (x,y,z) [meters]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1046,6 +1211,11 @@ struct MultiAntennaOffsetCorrection
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_id,offset,valid_flags);
+    }
+    
     uint8_t receiver_id = 0; ///< Receiver ID for the receiver to which the antenna is attached
     float offset[3] = {0}; ///< (x,y,z) [meters]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1068,6 +1238,11 @@ struct MultiAntennaOffsetCorrectionUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_MULTI_ANTENNA_OFFSET_CORRECTION_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_id,offset_uncert,valid_flags);
+    }
     
     uint8_t receiver_id = 0; ///< Receiver ID for the receiver to which the antenna is attached
     float offset_uncert[3] = {0}; ///< (x,y,z) [meters]
@@ -1094,6 +1269,11 @@ struct MagnetometerOffset
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(hard_iron,valid_flags);
+    }
+    
     float hard_iron[3] = {0}; ///< (x,y,z) [Gauss]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1118,6 +1298,11 @@ struct MagnetometerMatrix
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(soft_iron,valid_flags);
+    }
+    
     float soft_iron[9] = {0}; ///< Row-major [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1139,6 +1324,11 @@ struct MagnetometerOffsetUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_MAG_COMPENSATION_OFFSET_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(hard_iron_uncertainty,valid_flags);
+    }
     
     float hard_iron_uncertainty[3] = {0}; ///< (x,y,z) [Gauss]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1162,6 +1352,11 @@ struct MagnetometerMatrixUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(soft_iron_uncertainty,valid_flags);
+    }
+    
     float soft_iron_uncertainty[9] = {0}; ///< Row-major [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1182,6 +1377,11 @@ struct MagnetometerCovarianceMatrix
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_MAG_COVARIANCE;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(covariance,valid_flags);
+    }
     
     float covariance[9] = {0};
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1205,6 +1405,11 @@ struct MagnetometerResidualVector
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(residual,valid_flags);
+    }
+    
     float residual[3] = {0}; ///< (x,y,z) [Gauss]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1226,6 +1431,11 @@ struct ClockCorrection
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_CLOCK_CORRECTION;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_id,bias,bias_drift,valid_flags);
+    }
     
     uint8_t receiver_id = 0; ///< 1, 2, etc.
     float bias = 0; ///< [seconds]
@@ -1251,6 +1461,11 @@ struct ClockCorrectionUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_id,bias_uncertainty,bias_drift_uncertainty,valid_flags);
+    }
+    
     uint8_t receiver_id = 0; ///< 1, 2, etc.
     float bias_uncertainty = 0; ///< [seconds]
     float bias_drift_uncertainty = 0; ///< [seconds/second]
@@ -1274,6 +1489,11 @@ struct GnssPosAidStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_GNSS_POS_AID_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_id,time_of_week,status,reserved);
+    }
     
     uint8_t receiver_id = 0;
     float time_of_week = 0; ///< Last GNSS aiding measurement time of week [seconds]
@@ -1299,6 +1519,11 @@ struct GnssAttAidStatus
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,status,reserved);
+    }
+    
     float time_of_week = 0; ///< Last valid aiding measurement time of week [seconds] [processed instead of measured?]
     GnssAidStatusFlags status; ///< Last valid aiding measurement status bitfield
     uint8_t reserved[8] = {0};
@@ -1321,6 +1546,11 @@ struct HeadAidStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_HEAD_AID_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,type,reserved);
+    }
     
     enum class HeadingAidType : uint8_t
     {
@@ -1351,6 +1581,11 @@ struct RelPosNed
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(relative_position,valid_flags);
+    }
+    
     double relative_position[3] = {0}; ///< [meters, NED]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1372,6 +1607,11 @@ struct EcefPos
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ECEF_POS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(position_ecef,valid_flags);
+    }
     
     double position_ecef[3] = {0}; ///< [meters, ECEF]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 valid
@@ -1395,6 +1635,11 @@ struct EcefVel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(velocity_ecef,valid_flags);
+    }
+    
     float velocity_ecef[3] = {0}; ///< [meters/second, ECEF]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 valid
     
@@ -1416,6 +1661,11 @@ struct EcefPosUncertainty
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_ECEF_POS_UNCERTAINTY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(pos_uncertainty,valid_flags);
+    }
     
     float pos_uncertainty[3] = {0}; ///< [meters]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
@@ -1439,6 +1689,11 @@ struct EcefVelUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(vel_uncertainty,valid_flags);
+    }
+    
     float vel_uncertainty[3] = {0}; ///< [meters/second]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1460,6 +1715,11 @@ struct AidingMeasurementSummary
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_AID_MEAS_SUMMARY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,source,type,indicator);
+    }
     
     float time_of_week = 0; ///< [seconds]
     uint8_t source = 0;
@@ -1485,6 +1745,11 @@ struct OdometerScaleFactorError
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor_error,valid_flags);
+    }
+    
     float scale_factor_error = 0; ///< [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1507,6 +1772,11 @@ struct OdometerScaleFactorErrorUncertainty
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scale_factor_error_uncertainty,valid_flags);
+    }
+    
     float scale_factor_error_uncertainty = 0; ///< [dimensionless]
     uint16_t valid_flags = 0; ///< 0 - invalid, 1 - valid
     
@@ -1528,6 +1798,11 @@ struct GnssDualAntennaStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_filter::DATA_GNSS_DUAL_ANTENNA_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,heading,heading_unc,fix_type,status_flags,valid_flags);
+    }
     
     enum class FixType : uint8_t
     {

--- a/src/mip/definitions/data_gnss.hpp
+++ b/src/mip/definitions/data_gnss.hpp
@@ -180,6 +180,11 @@ struct PosLlh
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(latitude,longitude,ellipsoid_height,msl_height,horizontal_accuracy,vertical_accuracy,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -230,6 +235,11 @@ struct PosEcef
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(x,x_accuracy,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -272,6 +282,11 @@ struct VelNed
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_VELOCITY_NED;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(v,speed,ground_speed,heading,speed_accuracy,heading_accuracy,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -324,6 +339,11 @@ struct VelEcef
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(v,v_accuracy,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -366,6 +386,11 @@ struct Dop
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_DOP;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(gdop,pdop,hdop,vdop,tdop,ndop,edop,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -420,6 +445,11 @@ struct UtcTime
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(year,month,day,hour,min,sec,msec,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -468,6 +498,11 @@ struct GpsTime
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(tow,week_number,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -510,6 +545,11 @@ struct ClockInfo
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_CLOCK_INFO;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias,drift,accuracy_estimate,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -555,6 +595,11 @@ struct FixInfo
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_FIX_INFO;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(fix_type,num_sv,fix_flags,valid_flags);
+    }
     
     enum class FixType : uint8_t
     {
@@ -633,6 +678,11 @@ struct SvInfo
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(channel,sv_id,carrier_noise_ratio,azimuth,elevation,sv_flags,valid_flags);
+    }
+    
     struct SVFlags : Bitfield<SVFlags>
     {
         enum _enumType : uint16_t
@@ -702,6 +752,11 @@ struct HwStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_HW_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(receiver_state,antenna_state,antenna_power,valid_flags);
+    }
     
     enum class ReceiverState : uint8_t
     {
@@ -783,6 +838,11 @@ struct DgpsInfo
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(sv_id,age,range_correction,range_rate_correction,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -831,6 +891,11 @@ struct DgpsChannel
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_DGPS_CHANNEL_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(sv_id,age,range_correction,range_rate_correction,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -881,6 +946,11 @@ struct ClockInfo2
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(bias,drift,bias_accuracy_estimate,drift_accuracy_estimate,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -928,6 +998,11 @@ struct GpsLeapSeconds
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(leap_seconds,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -967,6 +1042,11 @@ struct SbasInfo
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_SBAS_INFO;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,week_number,sbas_system,sbas_id,count,sbas_status,valid_flags);
+    }
     
     struct SbasStatus : Bitfield<SbasStatus>
     {
@@ -1062,6 +1142,11 @@ struct SbasCorrection
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,gnss_id,sv_id,udrei,pseudorange_correction,iono_correction,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -1112,6 +1197,11 @@ struct RfErrorDetection
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_RF_ERROR_DETECTION;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(rf_band,jamming_state,spoofing_state,reserved,valid_flags);
+    }
     
     enum class RFBand : uint8_t
     {
@@ -1184,6 +1274,11 @@ struct BaseStationInfo
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_BASE_STATION_INFO;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,week_number,ecef_pos,height,station_id,indicators,valid_flags);
+    }
     
     struct IndicatorFlags : Bitfield<IndicatorFlags>
     {
@@ -1260,6 +1355,11 @@ struct RtkCorrectionsStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_RTK_CORRECTIONS_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,week_number,epoch_status,dongle_status,gps_correction_latency,glonass_correction_latency,galileo_correction_latency,beidou_correction_latency,reserved,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -1343,6 +1443,11 @@ struct SatelliteStatus
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,gnss_id,satellite_id,elevation,azimuth,health,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -1397,6 +1502,11 @@ struct Raw
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_RAW;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,receiver_id,tracking_channel,gnss_id,satellite_id,signal_id,signal_strength,quality,pseudorange,carrier_phase,doppler,range_uncert,phase_uncert,doppler_uncert,lock_time,valid_flags);
+    }
     
     enum class GnssSignalQuality : uint8_t
     {
@@ -1481,6 +1591,11 @@ struct GpsEphemeris
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,satellite_id,health,iodc,iode,t_oc,af0,af1,af2,t_gd,ISC_L1CA,ISC_L2C,t_oe,a,a_dot,mean_anomaly,delta_mean_motion,delta_mean_motion_dot,eccentricity,argument_of_perigee,omega,omega_dot,inclination,inclination_dot,c_ic,c_is,c_uc,c_us,c_rc,c_rs,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -1554,6 +1669,11 @@ struct GalileoEphemeris
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_GALILEO_EPHEMERIS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,satellite_id,health,iodc,iode,t_oc,af0,af1,af2,t_gd,ISC_L1CA,ISC_L2C,t_oe,a,a_dot,mean_anomaly,delta_mean_motion,delta_mean_motion_dot,eccentricity,argument_of_perigee,omega,omega_dot,inclination,inclination_dot,c_ic,c_is,c_uc,c_us,c_rc,c_rs,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -1629,6 +1749,11 @@ struct GloEphemeris
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(index,count,time_of_week,week_number,satellite_id,freq_number,tk,tb,sat_type,gamma,tau_n,x,v,a,health,P,NT,delta_tau_n,Ft,En,P1,P2,P3,P4,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -1693,6 +1818,11 @@ struct GpsIonoCorr
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,week_number,alpha,beta,valid_flags);
+    }
+    
     struct ValidFlags : Bitfield<ValidFlags>
     {
         enum _enumType : uint16_t
@@ -1739,6 +1869,11 @@ struct GalileoIonoCorr
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_gnss::DATA_GALILEO_IONO_CORR;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_of_week,week_number,alpha,disturbance_flags,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {

--- a/src/mip/definitions/data_sensor.hpp
+++ b/src/mip/definitions/data_sensor.hpp
@@ -83,6 +83,11 @@ struct RawAccel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(raw_accel);
+    }
+    
     float raw_accel[3] = {0}; ///< Native sensor counts
     
 };
@@ -104,6 +109,11 @@ struct RawGyro
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_GYRO_RAW;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(raw_gyro);
+    }
     
     float raw_gyro[3] = {0}; ///< Native sensor counts
     
@@ -127,6 +137,11 @@ struct RawMag
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(raw_mag);
+    }
+    
     float raw_mag[3] = {0}; ///< Native sensor counts
     
 };
@@ -148,6 +163,11 @@ struct RawPressure
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_PRESSURE_RAW;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(raw_pressure);
+    }
     
     float raw_pressure = 0; ///< Native sensor counts
     
@@ -171,6 +191,11 @@ struct ScaledAccel
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scaled_accel);
+    }
+    
     float scaled_accel[3] = {0}; ///< (x, y, z)[g]
     
 };
@@ -192,6 +217,11 @@ struct ScaledGyro
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_GYRO_SCALED;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(scaled_gyro);
+    }
     
     float scaled_gyro[3] = {0}; ///< (x, y, z) [radians/second]
     
@@ -215,6 +245,11 @@ struct ScaledMag
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(scaled_mag);
+    }
+    
     float scaled_mag[3] = {0}; ///< (x, y, z) [Gauss]
     
 };
@@ -235,6 +270,11 @@ struct ScaledPressure
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_PRESSURE_SCALED;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(scaled_pressure);
+    }
     
     float scaled_pressure = 0; ///< [mBar]
     
@@ -258,6 +298,11 @@ struct DeltaTheta
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(delta_theta);
+    }
+    
     float delta_theta[3] = {0}; ///< (x, y, z) [radians]
     
 };
@@ -279,6 +324,11 @@ struct DeltaVelocity
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_DELTA_VELOCITY;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(delta_velocity);
+    }
     
     float delta_velocity[3] = {0}; ///< (x, y, z) [g*sec]
     
@@ -311,6 +361,11 @@ struct CompOrientationMatrix
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(m);
+    }
+    
     float m[9] = {0}; ///< Matrix elements in row-major order.
     
 };
@@ -340,6 +395,11 @@ struct CompQuaternion
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(q);
+    }
+    
     float q[4] = {0}; ///< Quaternion elements EQSTART q = (q_w, q_x, q_y, q_z) EQEND
     
 };
@@ -361,6 +421,11 @@ struct CompEulerAngles
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_COMP_EULER_ANGLES;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(roll,pitch,yaw);
+    }
     
     float roll = 0; ///< [radians]
     float pitch = 0; ///< [radians]
@@ -385,6 +450,11 @@ struct CompOrientationUpdateMatrix
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(m);
+    }
+    
     float m[9] = {0};
     
 };
@@ -405,6 +475,11 @@ struct OrientationRawTemp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_TEMPERATURE_RAW;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(raw_temp);
+    }
     
     uint16_t raw_temp[4] = {0};
     
@@ -427,6 +502,11 @@ struct InternalTimestamp
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(counts);
+    }
+    
     uint32_t counts = 0;
     
 };
@@ -447,6 +527,11 @@ struct PpsTimestamp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_TIME_STAMP_PPS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(seconds,useconds);
+    }
     
     uint32_t seconds = 0;
     uint32_t useconds = 0;
@@ -475,6 +560,11 @@ struct GpsTimestamp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_TIME_STAMP_GPS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(tow,week_number,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -525,6 +615,11 @@ struct TemperatureAbs
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(min_temp,max_temp,mean_temp);
+    }
+    
     float min_temp = 0; ///< [degC]
     float max_temp = 0; ///< [degC]
     float mean_temp = 0; ///< [degC]
@@ -554,6 +649,11 @@ struct UpVector
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(up);
+    }
+    
     float up[3] = {0}; ///< [Gs]
     
 };
@@ -578,6 +678,11 @@ struct NorthVector
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(north);
+    }
+    
     float north[3] = {0}; ///< [Gauss]
     
 };
@@ -597,6 +702,11 @@ struct OverrangeStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_OVERRANGE_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(status);
+    }
     
     struct Status : Bitfield<Status>
     {
@@ -644,6 +754,11 @@ struct OdometerData
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_sensor::DATA_ODOMETER;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(speed,uncertainty,valid_flags);
+    }
     
     float speed = 0; ///< Average speed over the time interval [m/s]. Can be negative for quadrature encoders.
     float uncertainty = 0; ///< Uncertainty of velocity [m/s].

--- a/src/mip/definitions/data_shared.hpp
+++ b/src/mip/definitions/data_shared.hpp
@@ -70,6 +70,11 @@ struct EventSource
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(trigger_id);
+    }
+    
     uint8_t trigger_id = 0; ///< Trigger ID number. If 0, this message was emitted due to being scheduled in the 3DM Message Format Command (0x0C,0x0F).
     
 };
@@ -93,6 +98,11 @@ struct Ticks
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_shared::DATA_TICKS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(ticks);
+    }
     
     uint32_t ticks = 0; ///< Ticks since powerup.
     
@@ -119,6 +129,11 @@ struct DeltaTicks
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(ticks);
+    }
+    
     uint32_t ticks = 0; ///< Ticks since last output.
     
 };
@@ -142,6 +157,11 @@ struct GpsTimestamp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_shared::DATA_GPS_TIME;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(tow,week_number,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -195,6 +215,11 @@ struct DeltaTime
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(seconds);
+    }
+    
     double seconds = 0; ///< Seconds since last output.
     
 };
@@ -222,6 +247,11 @@ struct ReferenceTimestamp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_shared::DATA_REFERENCE_TIME;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(nanoseconds);
+    }
     
     uint64_t nanoseconds = 0; ///< Nanoseconds since initialization.
     
@@ -253,6 +283,11 @@ struct ReferenceTimeDelta
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(dt_nanos);
+    }
+    
     uint64_t dt_nanos = 0; ///< Nanoseconds since the last occurrence of this field in a packet of the same descriptor set and event source.
     
 };
@@ -281,6 +316,11 @@ struct ExternalTimestamp
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_shared::DATA_EXTERNAL_TIME;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(nanoseconds,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {
@@ -333,6 +373,11 @@ struct ExternalTimeDelta
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_shared::DATA_SYS_TIME_DELTA;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(dt_nanos,valid_flags);
+    }
     
     struct ValidFlags : Bitfield<ValidFlags>
     {

--- a/src/mip/definitions/data_system.hpp
+++ b/src/mip/definitions/data_system.hpp
@@ -78,6 +78,11 @@ struct BuiltInTest
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(result);
+    }
+    
     uint8_t result[16] = {0}; ///< Device-specific bitfield (128 bits). See device user manual. Bits are least-significant-byte first. For example, bit 0 is located at bit 0 of result[0], bit 1 is located at bit 1 of result[0], bit 8 is located at bit 0 of result[1], and bit 127 is located at bit 7 of result[15].
     
 };
@@ -98,6 +103,11 @@ struct TimeSyncStatus
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_system::DATA_TIME_SYNC_STATUS;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(time_sync,last_pps_rcvd);
+    }
     
     bool time_sync = 0; ///< True if sync with the PPS signal is currently valid. False if PPS feature is disabled or a PPS signal is not detected.
     uint8_t last_pps_rcvd = 0; ///< Elapsed time in seconds since last PPS was received, with a maximum value of 255.
@@ -139,6 +149,11 @@ struct GpioState
     
     static const bool HAS_FUNCTION_SELECTOR = false;
     
+    auto as_tuple() const
+    {
+        return std::make_tuple(states);
+    }
+    
     uint8_t states = 0; ///< Bitfield containing the states for each GPIO pin.<br/> Bit 0 (0x01): pin 1<br/> Bit 1 (0x02): pin 2<br/> Bit 2 (0x04): pin 3<br/> Bit 3 (0x08): pin 4<br/> Bits for pins that don't exist will read as 0.
     
 };
@@ -160,6 +175,11 @@ struct GpioAnalogValue
     static const uint8_t FIELD_DESCRIPTOR = ::mip::data_system::DATA_GPIO_ANALOG_VALUE;
     
     static const bool HAS_FUNCTION_SELECTOR = false;
+    
+    auto as_tuple() const
+    {
+        return std::make_tuple(gpio_id,value);
+    }
     
     uint8_t gpio_id = 0; ///< GPIO pin number starting with 1.
     float value = 0; ///< Value of the GPIO line in scaled volts.


### PR DESCRIPTION
* Add as_tuple() function to data fields to allow extracting parameters by index (using std::get).
* Move xxx_count (i.e. counts that aren't serialized) fields to after the thing they're counting.