### PR TITLE
Filter Mode edit to CV7_example.cpp

### DIFF
--- a/examples/CV7/CV7_example.cpp
+++ b/examples/CV7/CV7_example.cpp
@@ -277,7 +277,7 @@ int main(int argc, const char* argv[])
             filter_state_ahrs = true;
         }
 
-        //Once in full nav, print out data at 10 Hz
+        //Once in AHRS Flter Mode, print out data at 10 Hz
         if(filter_state_ahrs)
         {
            mip::Timestamp curr_timestamp = getCurrentTimestamp();


### PR DESCRIPTION
Changed ln 280 to say "Once in AHRS Filter Mode ..." from "Once in full nav mode ..." because Full Nav mode is not supported on CV7-AHRS.