### PR TITLE
Exclusive Serial Port Access

### DIFF
--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -78,6 +78,8 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
     if(SetupComm(port->handle, COM_PORT_BUFFER_SIZE, COM_PORT_BUFFER_SIZE) == 0)
     {
         MIP_LOG_ERROR("Unable to setup com port buffer size (%d)\n", GetLastError());
+        CloseHandle(port->handle);
+        port->handle = INVALID_HANDLE_VALUE;
         return false;
     }
 
@@ -102,6 +104,7 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
     {
         MIP_LOG_ERROR("Unable to get com state\n");
         CloseHandle(port->handle);
+        port->handle = INVALID_HANDLE_VALUE;
         return false;
     }
 
@@ -119,6 +122,7 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
     {
         MIP_LOG_ERROR("Unable to set com state\n");
         CloseHandle(port->handle);
+        port->handle = INVALID_HANDLE_VALUE;
         return false;
     }
 
@@ -132,17 +136,26 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
         return false;
     }
 
+    if( ioctl(port->handle, TIOCEXCL) < 0 )
+    {
+        MIP_LOG_WARN("Unable to set exclusive mode on serial port (%d): %s\n", errno, strerror(errno));
+    }
+
     // Set up baud rate and other serial device options
     struct termios serial_port_settings;
     if (tcgetattr(port->handle, &serial_port_settings) < 0)
     {
         MIP_LOG_ERROR("Unable to get serial port settings (%d): %s\n", errno, strerror(errno));
+        close(port->handle);
+        port->handle = -1;
         return false;
     }
 
     if (cfsetispeed(&serial_port_settings, baud_rate_to_speed(baudrate)) < 0 || cfsetospeed(&serial_port_settings, baud_rate_to_speed(baudrate)) < 0)
     {
         MIP_LOG_ERROR("Unable to set baud rate (%d): %s\n", errno, strerror(errno));
+        close(port->handle);
+        port->handle = -1;
         return false;
     }
 
@@ -160,22 +173,23 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
     if(tcsetattr(port->handle, TCSANOW, &serial_port_settings) < 0)
     {
         MIP_LOG_ERROR("Unable to save serial port settings (%d): %s\n", errno, strerror(errno));
+        close(port->handle);
+        port->handle = -1;
         return false;
     }
-    
+
     // Flush any waiting data
     tcflush(port->handle, TCIOFLUSH);
 
 #endif
 
     //Success
-    port->is_open = true;
     return true;
 }
 
 bool serial_port_close(serial_port *port)
 {
-    if(!port->is_open)
+    if(!serial_port_is_open(port))
         return false;
 
 #ifdef WIN32 //Windows
@@ -187,7 +201,6 @@ bool serial_port_close(serial_port *port)
     close(port->handle);
 #endif
 
-    port->is_open = false;
     return true;
 }
 
@@ -197,7 +210,7 @@ bool serial_port_write(serial_port *port, const void *buffer, size_t num_bytes, 
     *bytes_written = 0;
 
     //Check for a valid port handle
-    if(!port->is_open)
+    if(!serial_port_is_open(port))
         return false;
 
 #ifdef WIN32 //Windows
@@ -219,7 +232,7 @@ bool serial_port_write(serial_port *port, const void *buffer, size_t num_bytes, 
         return true;
     else if(*bytes_written == (size_t)-1)
         MIP_LOG_ERROR("Failed to write serial data (%d): %s\n", errno, strerror(errno));
-    
+
 #endif
 
     return false;
@@ -231,7 +244,7 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
     *bytes_read = 0;
 
     //Check for a valid port handle
-    if(!port->is_open)
+    if(!serial_port_is_open(port))
         return false;
 
 #ifdef WIN32 //Windows
@@ -278,7 +291,7 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
 uint32_t serial_port_read_count(serial_port *port)
 {
     //Check for a valid port handle
-    if(!port->is_open)
+    if(!serial_port_is_open(port))
         return 0;
 
 #ifdef WIN32 //Windows
@@ -303,5 +316,9 @@ uint32_t serial_port_read_count(serial_port *port)
 
 bool serial_port_is_open(serial_port *port)
 {
-    return port->is_open;
+#ifdef WIN32
+    return port->handle != INVALID_HANDLE_VALUE;
+#else
+    return port->handle >= 0;
+#endif
 }

--- a/src/mip/utils/serial_port.h
+++ b/src/mip/utils/serial_port.h
@@ -35,7 +35,6 @@ extern "C" {
 
 typedef struct serial_port
 {
-    bool is_open;
 #ifdef WIN32 //Windows
     HANDLE handle;
 #else //Linux


### PR DESCRIPTION
- Set exclusive access mode on Linux.
- Fix file descriptor leaks if serial port config fails after the handle is opened.
- Remove redundant is_open struct parameter and check the handle value directly.