### PR TITLE
Initializes serial port to invalid value so it doesn't show as connected when initialized

### DIFF
--- a/src/mip/platform/serial_connection.cpp
+++ b/src/mip/platform/serial_connection.cpp
@@ -38,7 +38,7 @@ bool SerialConnection::isConnected()
 bool SerialConnection::connect()
 {
     if (serial_port_is_open(&mPort))
-        return false;
+        return true;
 
    return serial_port_open(&mPort, mPortName.c_str(), mBaudrate);
 }

--- a/src/mip/platform/serial_connection.cpp
+++ b/src/mip/platform/serial_connection.cpp
@@ -19,11 +19,7 @@ SerialConnection::SerialConnection(const std::string& portName, uint32_t baudrat
     mBaudrate = baudrate;
     mType     = TYPE;
 
-    #ifdef WIN32
-    mPort.handle = INVALID_HANDLE_VALUE;
-#else
-    mPort.handle = 0;
-#endif
+    serial_port_init(&mPort);
 }
 
 ///@brief Closes the underlying serial port
@@ -42,7 +38,7 @@ bool SerialConnection::isConnected()
 bool SerialConnection::connect()
 {
     if (serial_port_is_open(&mPort))
-     return false;
+        return false;
 
    return serial_port_open(&mPort, mPortName.c_str(), mBaudrate);
 }
@@ -51,7 +47,7 @@ bool SerialConnection::connect()
 bool SerialConnection::disconnect()
 {
    if (!serial_port_is_open(&mPort))
-     return true;
+        return true;
 
    return serial_port_close(&mPort);
 }

--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -280,7 +280,13 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
         MIP_LOG_ERROR("Failed to poll serial port (%d): %s\n", errno, strerror(errno));
         return false;
     }
-    else if (poll_fd.revents & POLLERR || poll_fd.revents & POLLHUP || poll_fd.revents & POLLNVAL)
+    else if (poll_fd.revents & POLLHUP)
+    {
+        MIP_LOG_ERROR("Poll encountered HUP, closing device");
+        serial_port_close(port);
+        return false;
+    }
+    else if (poll_fd.revents & POLLERR || poll_fd.revents & POLLNVAL)
     {
         MIP_LOG_ERROR("Poll encountered error\n");
         return false;

--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -6,6 +6,9 @@
 #define COM_PORT_BUFFER_SIZE  0x200
 
 #ifndef WIN32 //Unix only
+
+#define INVALID_HANDLE_VALUE -1
+
 speed_t baud_rate_to_speed(int baud_rate)
 {
     switch(baud_rate)
@@ -53,6 +56,11 @@ speed_t baud_rate_to_speed(int baud_rate)
     }
 }
 #endif
+
+void serial_port_init(serial_port *port)
+{
+    port->handle = INVALID_HANDLE_VALUE;
+}
 
 bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
 {
@@ -193,15 +201,12 @@ bool serial_port_close(serial_port *port)
         return false;
 
 #ifdef WIN32 //Windows
-
     //Close the serial port
     CloseHandle(port->handle);
-    port->handle = INVALID_HANDLE_VALUE;
-
 #else //Linux
     close(port->handle);
-    port->handle   = 0;
 #endif
+    port->handle = INVALID_HANDLE_VALUE;
 
     return true;
 }
@@ -270,7 +275,17 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
     int poll_status = poll(&poll_fd, 1, wait_time);
 
     // Keep reading and polling while there is still data available
-    if (poll_status > 0 && poll_fd.revents & POLLIN)
+    if (poll_status == -1)
+    {
+        MIP_LOG_ERROR("Failed to poll serial port (%d): %s\n", errno, strerror(errno));
+        return false;
+    }
+    else if (poll_fd.revents & POLLERR || poll_fd.revents & POLLHUP || poll_fd.revents & POLLNVAL)
+    {
+        MIP_LOG_ERROR("Poll encountered error\n");
+        return false;
+    }
+    else if (poll_status > 0 && poll_fd.revents & POLLIN)
     {
         ssize_t local_bytes_read = read(port->handle, buffer, num_bytes);
 

--- a/src/mip/utils/serial_port.h
+++ b/src/mip/utils/serial_port.h
@@ -42,7 +42,7 @@ typedef struct serial_port
 #endif
 } serial_port;
 
-
+void serial_port_init(serial_port *port);
 bool serial_port_open(serial_port *port, const char *port_str, int baudrate);
 bool serial_port_close(serial_port *port);
 bool serial_port_write(serial_port *port, const void *buffer, size_t num_bytes, size_t *bytes_written);


### PR DESCRIPTION
Also checks the [poll](https://man7.org/linux/man-pages/man2/poll.2.html) `revents` field to properly detect errors such as disconnect