### PR TITLE
Generate MIP definitions from branches/dev@56028.

### DIFF
--- a/src/mip/definitions/commands_aiding.c
+++ b/src/mip/definitions/commands_aiding.c
@@ -57,127 +57,6 @@ void extract_mip_time_timebase(struct mip_serializer* serializer, mip_time_timeb
 // Mip Fields
 ////////////////////////////////////////////////////////////////////////////////
 
-void insert_mip_aiding_sensor_frame_mapping_command(mip_serializer* serializer, const mip_aiding_sensor_frame_mapping_command* self)
-{
-    insert_mip_function_selector(serializer, self->function);
-    
-    if( self->function == MIP_FUNCTION_WRITE )
-    {
-        insert_u8(serializer, self->sensor_id);
-        
-        insert_u8(serializer, self->frame_id);
-        
-    }
-}
-void extract_mip_aiding_sensor_frame_mapping_command(mip_serializer* serializer, mip_aiding_sensor_frame_mapping_command* self)
-{
-    extract_mip_function_selector(serializer, &self->function);
-    
-    if( self->function == MIP_FUNCTION_WRITE )
-    {
-        extract_u8(serializer, &self->sensor_id);
-        
-        extract_u8(serializer, &self->frame_id);
-        
-    }
-}
-
-void insert_mip_aiding_sensor_frame_mapping_response(mip_serializer* serializer, const mip_aiding_sensor_frame_mapping_response* self)
-{
-    insert_u8(serializer, self->sensor_id);
-    
-    insert_u8(serializer, self->frame_id);
-    
-}
-void extract_mip_aiding_sensor_frame_mapping_response(mip_serializer* serializer, mip_aiding_sensor_frame_mapping_response* self)
-{
-    extract_u8(serializer, &self->sensor_id);
-    
-    extract_u8(serializer, &self->frame_id);
-    
-}
-
-mip_cmd_result mip_aiding_write_sensor_frame_mapping(struct mip_interface* device, uint8_t sensor_id, uint8_t frame_id)
-{
-    mip_serializer serializer;
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    mip_serializer_init_insertion(&serializer, buffer, sizeof(buffer));
-    
-    insert_mip_function_selector(&serializer, MIP_FUNCTION_WRITE);
-    
-    insert_u8(&serializer, sensor_id);
-    
-    insert_u8(&serializer, frame_id);
-    
-    assert(mip_serializer_is_ok(&serializer));
-    
-    return mip_interface_run_command(device, MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-mip_cmd_result mip_aiding_read_sensor_frame_mapping(struct mip_interface* device, uint8_t* sensor_id_out, uint8_t* frame_id_out)
-{
-    mip_serializer serializer;
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    mip_serializer_init_insertion(&serializer, buffer, sizeof(buffer));
-    
-    insert_mip_function_selector(&serializer, MIP_FUNCTION_READ);
-    
-    assert(mip_serializer_is_ok(&serializer));
-    
-    uint8_t responseLength = sizeof(buffer);
-    mip_cmd_result result = mip_interface_run_command_with_response(device, MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer), MIP_REPLY_DESC_AIDING_SENSOR_FRAME_MAP, buffer, &responseLength);
-    
-    if( result == MIP_ACK_OK )
-    {
-        mip_serializer deserializer;
-        mip_serializer_init_insertion(&deserializer, buffer, responseLength);
-        
-        assert(sensor_id_out);
-        extract_u8(&deserializer, sensor_id_out);
-        
-        assert(frame_id_out);
-        extract_u8(&deserializer, frame_id_out);
-        
-        if( mip_serializer_remaining(&deserializer) != 0 )
-            result = MIP_STATUS_ERROR;
-    }
-    return result;
-}
-mip_cmd_result mip_aiding_save_sensor_frame_mapping(struct mip_interface* device)
-{
-    mip_serializer serializer;
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    mip_serializer_init_insertion(&serializer, buffer, sizeof(buffer));
-    
-    insert_mip_function_selector(&serializer, MIP_FUNCTION_SAVE);
-    
-    assert(mip_serializer_is_ok(&serializer));
-    
-    return mip_interface_run_command(device, MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-mip_cmd_result mip_aiding_load_sensor_frame_mapping(struct mip_interface* device)
-{
-    mip_serializer serializer;
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    mip_serializer_init_insertion(&serializer, buffer, sizeof(buffer));
-    
-    insert_mip_function_selector(&serializer, MIP_FUNCTION_LOAD);
-    
-    assert(mip_serializer_is_ok(&serializer));
-    
-    return mip_interface_run_command(device, MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-mip_cmd_result mip_aiding_default_sensor_frame_mapping(struct mip_interface* device)
-{
-    mip_serializer serializer;
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    mip_serializer_init_insertion(&serializer, buffer, sizeof(buffer));
-    
-    insert_mip_function_selector(&serializer, MIP_FUNCTION_RESET);
-    
-    assert(mip_serializer_is_ok(&serializer));
-    
-    return mip_interface_run_command(device, MIP_AIDING_CMD_DESC_SET, MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
 void insert_mip_aiding_reference_frame_command(mip_serializer* serializer, const mip_aiding_reference_frame_command* self)
 {
     insert_mip_function_selector(serializer, self->function);
@@ -527,7 +406,7 @@ void insert_mip_aiding_ecef_pos_command(mip_serializer* serializer, const mip_ai
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert_double(serializer, self->position[i]);
@@ -542,7 +421,7 @@ void extract_mip_aiding_ecef_pos_command(mip_serializer* serializer, mip_aiding_
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract_double(serializer, &self->position[i]);
@@ -565,7 +444,7 @@ void extract_mip_aiding_ecef_pos_command_valid_flags(struct mip_serializer* seri
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_ecef_pos(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const double* position, const float* uncertainty, mip_aiding_ecef_pos_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_ecef_pos(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const double* position, const float* uncertainty, mip_aiding_ecef_pos_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -574,7 +453,7 @@ mip_cmd_result mip_aiding_ecef_pos(struct mip_interface* device, const mip_time*
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     assert(position || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -594,7 +473,7 @@ void insert_mip_aiding_llh_pos_command(mip_serializer* serializer, const mip_aid
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     insert_double(serializer, self->latitude);
     
@@ -612,7 +491,7 @@ void extract_mip_aiding_llh_pos_command(mip_serializer* serializer, mip_aiding_l
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     extract_double(serializer, &self->latitude);
     
@@ -638,7 +517,7 @@ void extract_mip_aiding_llh_pos_command_valid_flags(struct mip_serializer* seria
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, double latitude, double longitude, double height, const float* uncertainty, mip_aiding_llh_pos_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* time, uint8_t frame_id, double latitude, double longitude, double height, const float* uncertainty, mip_aiding_llh_pos_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -647,7 +526,7 @@ mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* 
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     insert_double(&serializer, latitude);
     
@@ -669,7 +548,7 @@ void insert_mip_aiding_height_command(mip_serializer* serializer, const mip_aidi
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     insert_float(serializer, self->height);
     
@@ -682,7 +561,7 @@ void extract_mip_aiding_height_command(mip_serializer* serializer, mip_aiding_he
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     extract_float(serializer, &self->height);
     
@@ -692,7 +571,7 @@ void extract_mip_aiding_height_command(mip_serializer* serializer, mip_aiding_he
     
 }
 
-mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float height, float uncertainty, uint16_t valid_flags)
+mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float height, float uncertainty, uint16_t valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -701,7 +580,7 @@ mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* t
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     insert_float(&serializer, height);
     
@@ -717,7 +596,7 @@ void insert_mip_aiding_pressure_command(mip_serializer* serializer, const mip_ai
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     insert_float(serializer, self->pressure);
     
@@ -730,7 +609,7 @@ void extract_mip_aiding_pressure_command(mip_serializer* serializer, mip_aiding_
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     extract_float(serializer, &self->pressure);
     
@@ -740,7 +619,7 @@ void extract_mip_aiding_pressure_command(mip_serializer* serializer, mip_aiding_
     
 }
 
-mip_cmd_result mip_aiding_pressure(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float pressure, float uncertainty, uint16_t valid_flags)
+mip_cmd_result mip_aiding_pressure(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float pressure, float uncertainty, uint16_t valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -749,7 +628,7 @@ mip_cmd_result mip_aiding_pressure(struct mip_interface* device, const mip_time*
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     insert_float(&serializer, pressure);
     
@@ -765,7 +644,7 @@ void insert_mip_aiding_ecef_vel_command(mip_serializer* serializer, const mip_ai
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert_float(serializer, self->velocity[i]);
@@ -780,7 +659,7 @@ void extract_mip_aiding_ecef_vel_command(mip_serializer* serializer, mip_aiding_
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract_float(serializer, &self->velocity[i]);
@@ -803,7 +682,7 @@ void extract_mip_aiding_ecef_vel_command_valid_flags(struct mip_serializer* seri
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_ecef_vel(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_ecef_vel_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_ecef_vel(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_ecef_vel_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -812,7 +691,7 @@ mip_cmd_result mip_aiding_ecef_vel(struct mip_interface* device, const mip_time*
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -832,7 +711,7 @@ void insert_mip_aiding_ned_vel_command(mip_serializer* serializer, const mip_aid
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert_float(serializer, self->velocity[i]);
@@ -847,7 +726,7 @@ void extract_mip_aiding_ned_vel_command(mip_serializer* serializer, mip_aiding_n
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract_float(serializer, &self->velocity[i]);
@@ -870,7 +749,7 @@ void extract_mip_aiding_ned_vel_command_valid_flags(struct mip_serializer* seria
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_ned_vel(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_ned_vel_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_ned_vel(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_ned_vel_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -879,7 +758,7 @@ mip_cmd_result mip_aiding_ned_vel(struct mip_interface* device, const mip_time* 
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -899,7 +778,7 @@ void insert_mip_aiding_vehicle_fixed_frame_velocity_command(mip_serializer* seri
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert_float(serializer, self->velocity[i]);
@@ -914,7 +793,7 @@ void extract_mip_aiding_vehicle_fixed_frame_velocity_command(mip_serializer* ser
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract_float(serializer, &self->velocity[i]);
@@ -937,7 +816,7 @@ void extract_mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags(struct 
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -946,7 +825,7 @@ mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* dev
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -966,7 +845,7 @@ void insert_mip_aiding_true_heading_command(mip_serializer* serializer, const mi
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     insert_float(serializer, self->heading);
     
@@ -979,7 +858,7 @@ void extract_mip_aiding_true_heading_command(mip_serializer* serializer, mip_aid
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     extract_float(serializer, &self->heading);
     
@@ -989,7 +868,7 @@ void extract_mip_aiding_true_heading_command(mip_serializer* serializer, mip_aid
     
 }
 
-mip_cmd_result mip_aiding_true_heading(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float heading, float uncertainty, uint16_t valid_flags)
+mip_cmd_result mip_aiding_true_heading(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float heading, float uncertainty, uint16_t valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -998,7 +877,7 @@ mip_cmd_result mip_aiding_true_heading(struct mip_interface* device, const mip_t
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     insert_float(&serializer, heading);
     
@@ -1014,7 +893,7 @@ void insert_mip_aiding_magnetic_field_command(mip_serializer* serializer, const 
 {
     insert_mip_time(serializer, &self->time);
     
-    insert_u8(serializer, self->sensor_id);
+    insert_u8(serializer, self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert_float(serializer, self->magnetic_field[i]);
@@ -1029,7 +908,7 @@ void extract_mip_aiding_magnetic_field_command(mip_serializer* serializer, mip_a
 {
     extract_mip_time(serializer, &self->time);
     
-    extract_u8(serializer, &self->sensor_id);
+    extract_u8(serializer, &self->frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract_float(serializer, &self->magnetic_field[i]);
@@ -1052,7 +931,7 @@ void extract_mip_aiding_magnetic_field_command_valid_flags(struct mip_serializer
     *self = tmp;
 }
 
-mip_cmd_result mip_aiding_magnetic_field(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* magnetic_field, const float* uncertainty, mip_aiding_magnetic_field_command_valid_flags valid_flags)
+mip_cmd_result mip_aiding_magnetic_field(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* magnetic_field, const float* uncertainty, mip_aiding_magnetic_field_command_valid_flags valid_flags)
 {
     mip_serializer serializer;
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
@@ -1061,7 +940,7 @@ mip_cmd_result mip_aiding_magnetic_field(struct mip_interface* device, const mip
     assert(time);
     insert_mip_time(&serializer, time);
     
-    insert_u8(&serializer, sensor_id);
+    insert_u8(&serializer, frame_id);
     
     assert(magnetic_field || (3 == 0));
     for(unsigned int i=0; i < 3; i++)

--- a/src/mip/definitions/commands_aiding.cpp
+++ b/src/mip/definitions/commands_aiding.cpp
@@ -48,116 +48,6 @@ void extract(Serializer& serializer, Time& self)
 // Mip Fields
 ////////////////////////////////////////////////////////////////////////////////
 
-void insert(Serializer& serializer, const SensorFrameMapping& self)
-{
-    insert(serializer, self.function);
-    
-    if( self.function == FunctionSelector::WRITE )
-    {
-        insert(serializer, self.sensor_id);
-        
-        insert(serializer, self.frame_id);
-        
-    }
-}
-void extract(Serializer& serializer, SensorFrameMapping& self)
-{
-    extract(serializer, self.function);
-    
-    if( self.function == FunctionSelector::WRITE )
-    {
-        extract(serializer, self.sensor_id);
-        
-        extract(serializer, self.frame_id);
-        
-    }
-}
-
-void insert(Serializer& serializer, const SensorFrameMapping::Response& self)
-{
-    insert(serializer, self.sensor_id);
-    
-    insert(serializer, self.frame_id);
-    
-}
-void extract(Serializer& serializer, SensorFrameMapping::Response& self)
-{
-    extract(serializer, self.sensor_id);
-    
-    extract(serializer, self.frame_id);
-    
-}
-
-TypedResult<SensorFrameMapping> writeSensorFrameMapping(C::mip_interface& device, uint8_t sensorId, uint8_t frameId)
-{
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    Serializer serializer(buffer, sizeof(buffer));
-    
-    insert(serializer, FunctionSelector::WRITE);
-    insert(serializer, sensorId);
-    
-    insert(serializer, frameId);
-    
-    assert(serializer.isOk());
-    
-    return mip_interface_run_command(&device, DESCRIPTOR_SET, CMD_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-TypedResult<SensorFrameMapping> readSensorFrameMapping(C::mip_interface& device, uint8_t* sensorIdOut, uint8_t* frameIdOut)
-{
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    Serializer serializer(buffer, sizeof(buffer));
-    
-    insert(serializer, FunctionSelector::READ);
-    assert(serializer.isOk());
-    
-    uint8_t responseLength = sizeof(buffer);
-    TypedResult<SensorFrameMapping> result = mip_interface_run_command_with_response(&device, DESCRIPTOR_SET, CMD_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer), REPLY_SENSOR_FRAME_MAP, buffer, &responseLength);
-    
-    if( result == MIP_ACK_OK )
-    {
-        Serializer deserializer(buffer, responseLength);
-        
-        assert(sensorIdOut);
-        extract(deserializer, *sensorIdOut);
-        
-        assert(frameIdOut);
-        extract(deserializer, *frameIdOut);
-        
-        if( deserializer.remaining() != 0 )
-            result = MIP_STATUS_ERROR;
-    }
-    return result;
-}
-TypedResult<SensorFrameMapping> saveSensorFrameMapping(C::mip_interface& device)
-{
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    Serializer serializer(buffer, sizeof(buffer));
-    
-    insert(serializer, FunctionSelector::SAVE);
-    assert(serializer.isOk());
-    
-    return mip_interface_run_command(&device, DESCRIPTOR_SET, CMD_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-TypedResult<SensorFrameMapping> loadSensorFrameMapping(C::mip_interface& device)
-{
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    Serializer serializer(buffer, sizeof(buffer));
-    
-    insert(serializer, FunctionSelector::LOAD);
-    assert(serializer.isOk());
-    
-    return mip_interface_run_command(&device, DESCRIPTOR_SET, CMD_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
-TypedResult<SensorFrameMapping> defaultSensorFrameMapping(C::mip_interface& device)
-{
-    uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
-    Serializer serializer(buffer, sizeof(buffer));
-    
-    insert(serializer, FunctionSelector::RESET);
-    assert(serializer.isOk());
-    
-    return mip_interface_run_command(&device, DESCRIPTOR_SET, CMD_SENSOR_FRAME_MAP, buffer, (uint8_t)mip_serializer_length(&serializer));
-}
 void insert(Serializer& serializer, const ReferenceFrame& self)
 {
     insert(serializer, self.function);
@@ -463,7 +353,7 @@ void insert(Serializer& serializer, const EcefPos& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert(serializer, self.position[i]);
@@ -478,7 +368,7 @@ void extract(Serializer& serializer, EcefPos& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract(serializer, self.position[i]);
@@ -490,14 +380,14 @@ void extract(Serializer& serializer, EcefPos& self)
     
 }
 
-TypedResult<EcefPos> ecefPos(C::mip_interface& device, const Time& time, uint8_t sensorId, const double* position, const float* uncertainty, EcefPos::ValidFlags validFlags)
+TypedResult<EcefPos> ecefPos(C::mip_interface& device, const Time& time, uint8_t frameId, const double* position, const float* uncertainty, EcefPos::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     assert(position || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -517,7 +407,7 @@ void insert(Serializer& serializer, const LlhPos& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     insert(serializer, self.latitude);
     
@@ -535,7 +425,7 @@ void extract(Serializer& serializer, LlhPos& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     extract(serializer, self.latitude);
     
@@ -550,14 +440,14 @@ void extract(Serializer& serializer, LlhPos& self)
     
 }
 
-TypedResult<LlhPos> llhPos(C::mip_interface& device, const Time& time, uint8_t sensorId, double latitude, double longitude, double height, const float* uncertainty, LlhPos::ValidFlags validFlags)
+TypedResult<LlhPos> llhPos(C::mip_interface& device, const Time& time, uint8_t frameId, double latitude, double longitude, double height, const float* uncertainty, LlhPos::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     insert(serializer, latitude);
     
@@ -579,7 +469,7 @@ void insert(Serializer& serializer, const Height& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     insert(serializer, self.height);
     
@@ -592,7 +482,7 @@ void extract(Serializer& serializer, Height& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     extract(serializer, self.height);
     
@@ -602,14 +492,14 @@ void extract(Serializer& serializer, Height& self)
     
 }
 
-TypedResult<Height> height(C::mip_interface& device, const Time& time, uint8_t sensorId, float height, float uncertainty, uint16_t validFlags)
+TypedResult<Height> height(C::mip_interface& device, const Time& time, uint8_t frameId, float height, float uncertainty, uint16_t validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     insert(serializer, height);
     
@@ -625,7 +515,7 @@ void insert(Serializer& serializer, const Pressure& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     insert(serializer, self.pressure);
     
@@ -638,7 +528,7 @@ void extract(Serializer& serializer, Pressure& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     extract(serializer, self.pressure);
     
@@ -648,14 +538,14 @@ void extract(Serializer& serializer, Pressure& self)
     
 }
 
-TypedResult<Pressure> pressure(C::mip_interface& device, const Time& time, uint8_t sensorId, float pressure, float uncertainty, uint16_t validFlags)
+TypedResult<Pressure> pressure(C::mip_interface& device, const Time& time, uint8_t frameId, float pressure, float uncertainty, uint16_t validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     insert(serializer, pressure);
     
@@ -671,7 +561,7 @@ void insert(Serializer& serializer, const EcefVel& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert(serializer, self.velocity[i]);
@@ -686,7 +576,7 @@ void extract(Serializer& serializer, EcefVel& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract(serializer, self.velocity[i]);
@@ -698,14 +588,14 @@ void extract(Serializer& serializer, EcefVel& self)
     
 }
 
-TypedResult<EcefVel> ecefVel(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, EcefVel::ValidFlags validFlags)
+TypedResult<EcefVel> ecefVel(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, EcefVel::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -725,7 +615,7 @@ void insert(Serializer& serializer, const NedVel& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert(serializer, self.velocity[i]);
@@ -740,7 +630,7 @@ void extract(Serializer& serializer, NedVel& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract(serializer, self.velocity[i]);
@@ -752,14 +642,14 @@ void extract(Serializer& serializer, NedVel& self)
     
 }
 
-TypedResult<NedVel> nedVel(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, NedVel::ValidFlags validFlags)
+TypedResult<NedVel> nedVel(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, NedVel::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -779,7 +669,7 @@ void insert(Serializer& serializer, const VehicleFixedFrameVelocity& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert(serializer, self.velocity[i]);
@@ -794,7 +684,7 @@ void extract(Serializer& serializer, VehicleFixedFrameVelocity& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract(serializer, self.velocity[i]);
@@ -806,14 +696,14 @@ void extract(Serializer& serializer, VehicleFixedFrameVelocity& self)
     
 }
 
-TypedResult<VehicleFixedFrameVelocity> vehicleFixedFrameVelocity(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, VehicleFixedFrameVelocity::ValidFlags validFlags)
+TypedResult<VehicleFixedFrameVelocity> vehicleFixedFrameVelocity(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, VehicleFixedFrameVelocity::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     assert(velocity || (3 == 0));
     for(unsigned int i=0; i < 3; i++)
@@ -833,7 +723,7 @@ void insert(Serializer& serializer, const TrueHeading& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     insert(serializer, self.heading);
     
@@ -846,7 +736,7 @@ void extract(Serializer& serializer, TrueHeading& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     extract(serializer, self.heading);
     
@@ -856,14 +746,14 @@ void extract(Serializer& serializer, TrueHeading& self)
     
 }
 
-TypedResult<TrueHeading> trueHeading(C::mip_interface& device, const Time& time, uint8_t sensorId, float heading, float uncertainty, uint16_t validFlags)
+TypedResult<TrueHeading> trueHeading(C::mip_interface& device, const Time& time, uint8_t frameId, float heading, float uncertainty, uint16_t validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     insert(serializer, heading);
     
@@ -879,7 +769,7 @@ void insert(Serializer& serializer, const MagneticField& self)
 {
     insert(serializer, self.time);
     
-    insert(serializer, self.sensor_id);
+    insert(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         insert(serializer, self.magnetic_field[i]);
@@ -894,7 +784,7 @@ void extract(Serializer& serializer, MagneticField& self)
 {
     extract(serializer, self.time);
     
-    extract(serializer, self.sensor_id);
+    extract(serializer, self.frame_id);
     
     for(unsigned int i=0; i < 3; i++)
         extract(serializer, self.magnetic_field[i]);
@@ -906,14 +796,14 @@ void extract(Serializer& serializer, MagneticField& self)
     
 }
 
-TypedResult<MagneticField> magneticField(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* magneticField, const float* uncertainty, MagneticField::ValidFlags validFlags)
+TypedResult<MagneticField> magneticField(C::mip_interface& device, const Time& time, uint8_t frameId, const float* magneticField, const float* uncertainty, MagneticField::ValidFlags validFlags)
 {
     uint8_t buffer[MIP_FIELD_PAYLOAD_LENGTH_MAX];
     Serializer serializer(buffer, sizeof(buffer));
     
     insert(serializer, time);
     
-    insert(serializer, sensorId);
+    insert(serializer, frameId);
     
     assert(magneticField || (3 == 0));
     for(unsigned int i=0; i < 3; i++)

--- a/src/mip/definitions/commands_aiding.h
+++ b/src/mip/definitions/commands_aiding.h
@@ -34,7 +34,6 @@ enum
     MIP_AIDING_CMD_DESC_SET                = 0x13,
     
     MIP_CMD_DESC_AIDING_FRAME_CONFIG       = 0x01,
-    MIP_CMD_DESC_AIDING_SENSOR_FRAME_MAP   = 0x02,
     MIP_CMD_DESC_AIDING_LOCAL_FRAME        = 0x03,
     MIP_CMD_DESC_AIDING_ECHO_CONTROL       = 0x1F,
     MIP_CMD_DESC_AIDING_POS_LOCAL          = 0x20,
@@ -53,7 +52,6 @@ enum
     MIP_CMD_DESC_AIDING_DELTA_ATTITUDE     = 0x39,
     MIP_CMD_DESC_AIDING_LOCAL_ANGULAR_RATE = 0x3A,
     
-    MIP_REPLY_DESC_AIDING_SENSOR_FRAME_MAP = 0x82,
     MIP_REPLY_DESC_AIDING_FRAME_CONFIG     = 0x81,
     MIP_REPLY_DESC_AIDING_ECHO_CONTROL     = 0x9F,
 };
@@ -86,40 +84,6 @@ void extract_mip_time_timebase(struct mip_serializer* serializer, mip_time_timeb
 // Mip Fields
 ////////////////////////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////////////////////////
-///@defgroup c_aiding_sensor_frame_mapping  (0x13,0x02) Sensor Frame Mapping [C]
-///
-///@{
-
-struct mip_aiding_sensor_frame_mapping_command
-{
-    mip_function_selector function;
-    uint8_t sensor_id; ///< Sensor ID to configure. Cannot be 0.
-    uint8_t frame_id; ///< Frame ID to assign to the sensor. Defaults to 1.
-    
-};
-typedef struct mip_aiding_sensor_frame_mapping_command mip_aiding_sensor_frame_mapping_command;
-void insert_mip_aiding_sensor_frame_mapping_command(struct mip_serializer* serializer, const mip_aiding_sensor_frame_mapping_command* self);
-void extract_mip_aiding_sensor_frame_mapping_command(struct mip_serializer* serializer, mip_aiding_sensor_frame_mapping_command* self);
-
-struct mip_aiding_sensor_frame_mapping_response
-{
-    uint8_t sensor_id; ///< Sensor ID to configure. Cannot be 0.
-    uint8_t frame_id; ///< Frame ID to assign to the sensor. Defaults to 1.
-    
-};
-typedef struct mip_aiding_sensor_frame_mapping_response mip_aiding_sensor_frame_mapping_response;
-void insert_mip_aiding_sensor_frame_mapping_response(struct mip_serializer* serializer, const mip_aiding_sensor_frame_mapping_response* self);
-void extract_mip_aiding_sensor_frame_mapping_response(struct mip_serializer* serializer, mip_aiding_sensor_frame_mapping_response* self);
-
-mip_cmd_result mip_aiding_write_sensor_frame_mapping(struct mip_interface* device, uint8_t sensor_id, uint8_t frame_id);
-mip_cmd_result mip_aiding_read_sensor_frame_mapping(struct mip_interface* device, uint8_t* sensor_id_out, uint8_t* frame_id_out);
-mip_cmd_result mip_aiding_save_sensor_frame_mapping(struct mip_interface* device);
-mip_cmd_result mip_aiding_load_sensor_frame_mapping(struct mip_interface* device);
-mip_cmd_result mip_aiding_default_sensor_frame_mapping(struct mip_interface* device);
-
-///@}
-///
 ////////////////////////////////////////////////////////////////////////////////
 ///@defgroup c_aiding_reference_frame  (0x13,0x01) Reference Frame [C]
 /// Defines a reference frame associated with a specific sensor frame ID.  The frame ID used in this command
@@ -251,7 +215,7 @@ static const mip_aiding_ecef_pos_command_valid_flags MIP_AIDING_ECEF_POS_COMMAND
 struct mip_aiding_ecef_pos_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Sensor ID.
+    uint8_t frame_id; ///< Sensor ID.
     mip_vector3d position; ///< ECEF position [m].
     mip_vector3f uncertainty; ///< ECEF position uncertainty [m].
     mip_aiding_ecef_pos_command_valid_flags valid_flags; ///< Valid flags.
@@ -264,7 +228,7 @@ void extract_mip_aiding_ecef_pos_command(struct mip_serializer* serializer, mip_
 void insert_mip_aiding_ecef_pos_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_ecef_pos_command_valid_flags self);
 void extract_mip_aiding_ecef_pos_command_valid_flags(struct mip_serializer* serializer, mip_aiding_ecef_pos_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_ecef_pos(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const double* position, const float* uncertainty, mip_aiding_ecef_pos_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_ecef_pos(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const double* position, const float* uncertainty, mip_aiding_ecef_pos_command_valid_flags valid_flags);
 
 ///@}
 ///
@@ -285,7 +249,7 @@ static const mip_aiding_llh_pos_command_valid_flags MIP_AIDING_LLH_POS_COMMAND_V
 struct mip_aiding_llh_pos_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Sensor ID.
+    uint8_t frame_id; ///< Sensor ID.
     double latitude; ///< [deg]
     double longitude; ///< [deg]
     double height; ///< [m]
@@ -300,7 +264,7 @@ void extract_mip_aiding_llh_pos_command(struct mip_serializer* serializer, mip_a
 void insert_mip_aiding_llh_pos_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_llh_pos_command_valid_flags self);
 void extract_mip_aiding_llh_pos_command_valid_flags(struct mip_serializer* serializer, mip_aiding_llh_pos_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, double latitude, double longitude, double height, const float* uncertainty, mip_aiding_llh_pos_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* time, uint8_t frame_id, double latitude, double longitude, double height, const float* uncertainty, mip_aiding_llh_pos_command_valid_flags valid_flags);
 
 ///@}
 ///
@@ -313,7 +277,7 @@ mip_cmd_result mip_aiding_llh_pos(struct mip_interface* device, const mip_time* 
 struct mip_aiding_height_command
 {
     mip_time time;
-    uint8_t sensor_id;
+    uint8_t frame_id;
     float height; ///< [m]
     float uncertainty; ///< [m]
     uint16_t valid_flags;
@@ -323,7 +287,7 @@ typedef struct mip_aiding_height_command mip_aiding_height_command;
 void insert_mip_aiding_height_command(struct mip_serializer* serializer, const mip_aiding_height_command* self);
 void extract_mip_aiding_height_command(struct mip_serializer* serializer, mip_aiding_height_command* self);
 
-mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float height, float uncertainty, uint16_t valid_flags);
+mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float height, float uncertainty, uint16_t valid_flags);
 
 ///@}
 ///
@@ -336,7 +300,7 @@ mip_cmd_result mip_aiding_height(struct mip_interface* device, const mip_time* t
 struct mip_aiding_pressure_command
 {
     mip_time time;
-    uint8_t sensor_id;
+    uint8_t frame_id;
     float pressure; ///< [mbar]
     float uncertainty; ///< [mbar]
     uint16_t valid_flags;
@@ -346,7 +310,7 @@ typedef struct mip_aiding_pressure_command mip_aiding_pressure_command;
 void insert_mip_aiding_pressure_command(struct mip_serializer* serializer, const mip_aiding_pressure_command* self);
 void extract_mip_aiding_pressure_command(struct mip_serializer* serializer, mip_aiding_pressure_command* self);
 
-mip_cmd_result mip_aiding_pressure(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float pressure, float uncertainty, uint16_t valid_flags);
+mip_cmd_result mip_aiding_pressure(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float pressure, float uncertainty, uint16_t valid_flags);
 
 ///@}
 ///
@@ -366,7 +330,7 @@ static const mip_aiding_ecef_vel_command_valid_flags MIP_AIDING_ECEF_VEL_COMMAND
 struct mip_aiding_ecef_vel_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Sensor ID.
+    uint8_t frame_id; ///< Sensor ID.
     mip_vector3f velocity; ///< ECEF velocity [m/s].
     mip_vector3f uncertainty; ///< ECEF velocity uncertainty [m/s].
     mip_aiding_ecef_vel_command_valid_flags valid_flags; ///< Valid flags.
@@ -379,7 +343,7 @@ void extract_mip_aiding_ecef_vel_command(struct mip_serializer* serializer, mip_
 void insert_mip_aiding_ecef_vel_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_ecef_vel_command_valid_flags self);
 void extract_mip_aiding_ecef_vel_command_valid_flags(struct mip_serializer* serializer, mip_aiding_ecef_vel_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_ecef_vel(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_ecef_vel_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_ecef_vel(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_ecef_vel_command_valid_flags valid_flags);
 
 ///@}
 ///
@@ -399,7 +363,7 @@ static const mip_aiding_ned_vel_command_valid_flags MIP_AIDING_NED_VEL_COMMAND_V
 struct mip_aiding_ned_vel_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Sensor ID.
+    uint8_t frame_id; ///< Sensor ID.
     mip_vector3f velocity; ///< NED velocity [m/s].
     mip_vector3f uncertainty; ///< NED velocity uncertainty [m/s].
     mip_aiding_ned_vel_command_valid_flags valid_flags; ///< Valid flags.
@@ -412,7 +376,7 @@ void extract_mip_aiding_ned_vel_command(struct mip_serializer* serializer, mip_a
 void insert_mip_aiding_ned_vel_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_ned_vel_command_valid_flags self);
 void extract_mip_aiding_ned_vel_command_valid_flags(struct mip_serializer* serializer, mip_aiding_ned_vel_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_ned_vel(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_ned_vel_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_ned_vel(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_ned_vel_command_valid_flags valid_flags);
 
 ///@}
 ///
@@ -433,7 +397,7 @@ static const mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags MIP_AID
 struct mip_aiding_vehicle_fixed_frame_velocity_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
+    uint8_t frame_id; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
     mip_vector3f velocity; ///< [m/s]
     mip_vector3f uncertainty; ///< [m/s] 1-sigma uncertainty (if uncertainty[i] <= 0, then velocity[i] should be treated as invalid and ingnored)
     mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags valid_flags;
@@ -446,7 +410,7 @@ void extract_mip_aiding_vehicle_fixed_frame_velocity_command(struct mip_serializ
 void insert_mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags self);
 void extract_mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags(struct mip_serializer* serializer, mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* velocity, const float* uncertainty, mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* velocity, const float* uncertainty, mip_aiding_vehicle_fixed_frame_velocity_command_valid_flags valid_flags);
 
 ///@}
 ///
@@ -458,7 +422,7 @@ mip_cmd_result mip_aiding_vehicle_fixed_frame_velocity(struct mip_interface* dev
 struct mip_aiding_true_heading_command
 {
     mip_time time;
-    uint8_t sensor_id;
+    uint8_t frame_id;
     float heading; ///< Heading in [radians]
     float uncertainty;
     uint16_t valid_flags;
@@ -468,7 +432,7 @@ typedef struct mip_aiding_true_heading_command mip_aiding_true_heading_command;
 void insert_mip_aiding_true_heading_command(struct mip_serializer* serializer, const mip_aiding_true_heading_command* self);
 void extract_mip_aiding_true_heading_command(struct mip_serializer* serializer, mip_aiding_true_heading_command* self);
 
-mip_cmd_result mip_aiding_true_heading(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, float heading, float uncertainty, uint16_t valid_flags);
+mip_cmd_result mip_aiding_true_heading(struct mip_interface* device, const mip_time* time, uint8_t frame_id, float heading, float uncertainty, uint16_t valid_flags);
 
 ///@}
 ///
@@ -488,7 +452,7 @@ static const mip_aiding_magnetic_field_command_valid_flags MIP_AIDING_MAGNETIC_F
 struct mip_aiding_magnetic_field_command
 {
     mip_time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
+    uint8_t frame_id; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
     mip_vector3f magnetic_field; ///< [G]
     mip_vector3f uncertainty; ///< [G] 1-sigma uncertainty (if uncertainty[i] <= 0, then magnetic_field[i] should be treated as invalid and ingnored)
     mip_aiding_magnetic_field_command_valid_flags valid_flags;
@@ -501,7 +465,7 @@ void extract_mip_aiding_magnetic_field_command(struct mip_serializer* serializer
 void insert_mip_aiding_magnetic_field_command_valid_flags(struct mip_serializer* serializer, const mip_aiding_magnetic_field_command_valid_flags self);
 void extract_mip_aiding_magnetic_field_command_valid_flags(struct mip_serializer* serializer, mip_aiding_magnetic_field_command_valid_flags* self);
 
-mip_cmd_result mip_aiding_magnetic_field(struct mip_interface* device, const mip_time* time, uint8_t sensor_id, const float* magnetic_field, const float* uncertainty, mip_aiding_magnetic_field_command_valid_flags valid_flags);
+mip_cmd_result mip_aiding_magnetic_field(struct mip_interface* device, const mip_time* time, uint8_t frame_id, const float* magnetic_field, const float* uncertainty, mip_aiding_magnetic_field_command_valid_flags valid_flags);
 
 ///@}
 ///

--- a/src/mip/definitions/commands_aiding.hpp
+++ b/src/mip/definitions/commands_aiding.hpp
@@ -33,7 +33,6 @@ enum
     DESCRIPTOR_SET         = 0x13,
     
     CMD_FRAME_CONFIG       = 0x01,
-    CMD_SENSOR_FRAME_MAP   = 0x02,
     CMD_LOCAL_FRAME        = 0x03,
     CMD_ECHO_CONTROL       = 0x1F,
     CMD_POS_LOCAL          = 0x20,
@@ -52,7 +51,6 @@ enum
     CMD_DELTA_ATTITUDE     = 0x39,
     CMD_LOCAL_ANGULAR_RATE = 0x3A,
     
-    REPLY_SENSOR_FRAME_MAP = 0x82,
     REPLY_FRAME_CONFIG     = 0x81,
     REPLY_ECHO_CONTROL     = 0x9F,
 };
@@ -83,83 +81,6 @@ void extract(Serializer& serializer, Time& self);
 // Mip Fields
 ////////////////////////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////////////////////////
-///@defgroup cpp_aiding_sensor_frame_mapping  (0x13,0x02) Sensor Frame Mapping [CPP]
-///
-///@{
-
-struct SensorFrameMapping
-{
-    FunctionSelector function = static_cast<FunctionSelector>(0);
-    uint8_t sensor_id = 0; ///< Sensor ID to configure. Cannot be 0.
-    uint8_t frame_id = 0; ///< Frame ID to assign to the sensor. Defaults to 1.
-    
-    static constexpr const uint8_t DESCRIPTOR_SET = ::mip::commands_aiding::DESCRIPTOR_SET;
-    static constexpr const uint8_t FIELD_DESCRIPTOR = ::mip::commands_aiding::CMD_SENSOR_FRAME_MAP;
-    static constexpr const CompositeDescriptor DESCRIPTOR = {DESCRIPTOR_SET, FIELD_DESCRIPTOR};
-    static constexpr const char* NAME = "SensorFrameMapping";
-    static constexpr const char* DOC_NAME = "Sensor ID to Frame Mapping";
-    
-    static constexpr const bool HAS_FUNCTION_SELECTOR = true;
-    static constexpr const uint32_t WRITE_PARAMS   = 0x8003;
-    static constexpr const uint32_t READ_PARAMS    = 0x8000;
-    static constexpr const uint32_t SAVE_PARAMS    = 0x8000;
-    static constexpr const uint32_t LOAD_PARAMS    = 0x8000;
-    static constexpr const uint32_t DEFAULT_PARAMS = 0x8000;
-    static constexpr const uint32_t ECHOED_PARAMS  = 0x0000;
-    static constexpr const uint32_t COUNTER_PARAMS = 0x00000000;
-    
-    auto as_tuple() const
-    {
-        return std::make_tuple(sensor_id,frame_id);
-    }
-    
-    auto as_tuple()
-    {
-        return std::make_tuple(std::ref(sensor_id),std::ref(frame_id));
-    }
-    
-    static SensorFrameMapping create_sld_all(::mip::FunctionSelector function)
-    {
-        SensorFrameMapping cmd;
-        cmd.function = function;
-        return cmd;
-    }
-    
-    struct Response
-    {
-        static constexpr const uint8_t DESCRIPTOR_SET = ::mip::commands_aiding::DESCRIPTOR_SET;
-        static constexpr const uint8_t FIELD_DESCRIPTOR = ::mip::commands_aiding::REPLY_SENSOR_FRAME_MAP;
-        static constexpr const CompositeDescriptor DESCRIPTOR = {DESCRIPTOR_SET, FIELD_DESCRIPTOR};
-        static constexpr const char* NAME = "SensorFrameMapping::Response";
-        static constexpr const char* DOC_NAME = "Sensor ID to Frame Mapping Response";
-        
-        static constexpr const uint32_t ECHOED_PARAMS  = 0x0000;
-        static constexpr const uint32_t COUNTER_PARAMS = 0x00000000;
-        uint8_t sensor_id = 0; ///< Sensor ID to configure. Cannot be 0.
-        uint8_t frame_id = 0; ///< Frame ID to assign to the sensor. Defaults to 1.
-        
-        
-        auto as_tuple()
-        {
-            return std::make_tuple(std::ref(sensor_id),std::ref(frame_id));
-        }
-    };
-};
-void insert(Serializer& serializer, const SensorFrameMapping& self);
-void extract(Serializer& serializer, SensorFrameMapping& self);
-
-void insert(Serializer& serializer, const SensorFrameMapping::Response& self);
-void extract(Serializer& serializer, SensorFrameMapping::Response& self);
-
-TypedResult<SensorFrameMapping> writeSensorFrameMapping(C::mip_interface& device, uint8_t sensorId, uint8_t frameId);
-TypedResult<SensorFrameMapping> readSensorFrameMapping(C::mip_interface& device, uint8_t* sensorIdOut, uint8_t* frameIdOut);
-TypedResult<SensorFrameMapping> saveSensorFrameMapping(C::mip_interface& device);
-TypedResult<SensorFrameMapping> loadSensorFrameMapping(C::mip_interface& device);
-TypedResult<SensorFrameMapping> defaultSensorFrameMapping(C::mip_interface& device);
-
-///@}
-///
 ////////////////////////////////////////////////////////////////////////////////
 ///@defgroup cpp_aiding_reference_frame  (0x13,0x01) Reference Frame [CPP]
 /// Defines a reference frame associated with a specific sensor frame ID.  The frame ID used in this command
@@ -400,7 +321,7 @@ struct EcefPos
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Sensor ID.
+    uint8_t frame_id = 0; ///< Sensor ID.
     Vector3d position; ///< ECEF position [m].
     Vector3f uncertainty; ///< ECEF position uncertainty [m].
     ValidFlags valid_flags; ///< Valid flags.
@@ -416,19 +337,19 @@ struct EcefPos
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,position,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,position,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(position),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(position),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const EcefPos& self);
 void extract(Serializer& serializer, EcefPos& self);
 
-TypedResult<EcefPos> ecefPos(C::mip_interface& device, const Time& time, uint8_t sensorId, const double* position, const float* uncertainty, EcefPos::ValidFlags validFlags);
+TypedResult<EcefPos> ecefPos(C::mip_interface& device, const Time& time, uint8_t frameId, const double* position, const float* uncertainty, EcefPos::ValidFlags validFlags);
 
 ///@}
 ///
@@ -473,7 +394,7 @@ struct LlhPos
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Sensor ID.
+    uint8_t frame_id = 0; ///< Sensor ID.
     double latitude = 0; ///< [deg]
     double longitude = 0; ///< [deg]
     double height = 0; ///< [m]
@@ -491,19 +412,19 @@ struct LlhPos
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,latitude,longitude,height,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,latitude,longitude,height,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(latitude),std::ref(longitude),std::ref(height),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(latitude),std::ref(longitude),std::ref(height),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const LlhPos& self);
 void extract(Serializer& serializer, LlhPos& self);
 
-TypedResult<LlhPos> llhPos(C::mip_interface& device, const Time& time, uint8_t sensorId, double latitude, double longitude, double height, const float* uncertainty, LlhPos::ValidFlags validFlags);
+TypedResult<LlhPos> llhPos(C::mip_interface& device, const Time& time, uint8_t frameId, double latitude, double longitude, double height, const float* uncertainty, LlhPos::ValidFlags validFlags);
 
 ///@}
 ///
@@ -516,7 +437,7 @@ TypedResult<LlhPos> llhPos(C::mip_interface& device, const Time& time, uint8_t s
 struct Height
 {
     Time time;
-    uint8_t sensor_id = 0;
+    uint8_t frame_id = 0;
     float height = 0; ///< [m]
     float uncertainty = 0; ///< [m]
     uint16_t valid_flags = 0;
@@ -532,19 +453,19 @@ struct Height
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,height,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,height,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(height),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(height),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const Height& self);
 void extract(Serializer& serializer, Height& self);
 
-TypedResult<Height> height(C::mip_interface& device, const Time& time, uint8_t sensorId, float height, float uncertainty, uint16_t validFlags);
+TypedResult<Height> height(C::mip_interface& device, const Time& time, uint8_t frameId, float height, float uncertainty, uint16_t validFlags);
 
 ///@}
 ///
@@ -557,7 +478,7 @@ TypedResult<Height> height(C::mip_interface& device, const Time& time, uint8_t s
 struct Pressure
 {
     Time time;
-    uint8_t sensor_id = 0;
+    uint8_t frame_id = 0;
     float pressure = 0; ///< [mbar]
     float uncertainty = 0; ///< [mbar]
     uint16_t valid_flags = 0;
@@ -573,19 +494,19 @@ struct Pressure
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,pressure,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,pressure,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(pressure),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(pressure),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const Pressure& self);
 void extract(Serializer& serializer, Pressure& self);
 
-TypedResult<Pressure> pressure(C::mip_interface& device, const Time& time, uint8_t sensorId, float pressure, float uncertainty, uint16_t validFlags);
+TypedResult<Pressure> pressure(C::mip_interface& device, const Time& time, uint8_t frameId, float pressure, float uncertainty, uint16_t validFlags);
 
 ///@}
 ///
@@ -629,7 +550,7 @@ struct EcefVel
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Sensor ID.
+    uint8_t frame_id = 0; ///< Sensor ID.
     Vector3f velocity; ///< ECEF velocity [m/s].
     Vector3f uncertainty; ///< ECEF velocity uncertainty [m/s].
     ValidFlags valid_flags; ///< Valid flags.
@@ -645,19 +566,19 @@ struct EcefVel
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,velocity,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,velocity,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const EcefVel& self);
 void extract(Serializer& serializer, EcefVel& self);
 
-TypedResult<EcefVel> ecefVel(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, EcefVel::ValidFlags validFlags);
+TypedResult<EcefVel> ecefVel(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, EcefVel::ValidFlags validFlags);
 
 ///@}
 ///
@@ -701,7 +622,7 @@ struct NedVel
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Sensor ID.
+    uint8_t frame_id = 0; ///< Sensor ID.
     Vector3f velocity; ///< NED velocity [m/s].
     Vector3f uncertainty; ///< NED velocity uncertainty [m/s].
     ValidFlags valid_flags; ///< Valid flags.
@@ -717,19 +638,19 @@ struct NedVel
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,velocity,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,velocity,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const NedVel& self);
 void extract(Serializer& serializer, NedVel& self);
 
-TypedResult<NedVel> nedVel(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, NedVel::ValidFlags validFlags);
+TypedResult<NedVel> nedVel(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, NedVel::ValidFlags validFlags);
 
 ///@}
 ///
@@ -774,7 +695,7 @@ struct VehicleFixedFrameVelocity
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
+    uint8_t frame_id = 0; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
     Vector3f velocity; ///< [m/s]
     Vector3f uncertainty; ///< [m/s] 1-sigma uncertainty (if uncertainty[i] <= 0, then velocity[i] should be treated as invalid and ingnored)
     ValidFlags valid_flags;
@@ -790,19 +711,19 @@ struct VehicleFixedFrameVelocity
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,velocity,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,velocity,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(velocity),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const VehicleFixedFrameVelocity& self);
 void extract(Serializer& serializer, VehicleFixedFrameVelocity& self);
 
-TypedResult<VehicleFixedFrameVelocity> vehicleFixedFrameVelocity(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* velocity, const float* uncertainty, VehicleFixedFrameVelocity::ValidFlags validFlags);
+TypedResult<VehicleFixedFrameVelocity> vehicleFixedFrameVelocity(C::mip_interface& device, const Time& time, uint8_t frameId, const float* velocity, const float* uncertainty, VehicleFixedFrameVelocity::ValidFlags validFlags);
 
 ///@}
 ///
@@ -814,7 +735,7 @@ TypedResult<VehicleFixedFrameVelocity> vehicleFixedFrameVelocity(C::mip_interfac
 struct TrueHeading
 {
     Time time;
-    uint8_t sensor_id = 0;
+    uint8_t frame_id = 0;
     float heading = 0; ///< Heading in [radians]
     float uncertainty = 0;
     uint16_t valid_flags = 0;
@@ -830,19 +751,19 @@ struct TrueHeading
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,heading,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,heading,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(heading),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(heading),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const TrueHeading& self);
 void extract(Serializer& serializer, TrueHeading& self);
 
-TypedResult<TrueHeading> trueHeading(C::mip_interface& device, const Time& time, uint8_t sensorId, float heading, float uncertainty, uint16_t validFlags);
+TypedResult<TrueHeading> trueHeading(C::mip_interface& device, const Time& time, uint8_t frameId, float heading, float uncertainty, uint16_t validFlags);
 
 ///@}
 ///
@@ -886,7 +807,7 @@ struct MagneticField
     };
     
     Time time; ///< Timestamp of the measurement.
-    uint8_t sensor_id = 0; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
+    uint8_t frame_id = 0; ///< Source ID for this estimate ( source_id == 0 indicates this sensor, source_id > 0 indicates an external estimate )
     Vector3f magnetic_field; ///< [G]
     Vector3f uncertainty; ///< [G] 1-sigma uncertainty (if uncertainty[i] <= 0, then magnetic_field[i] should be treated as invalid and ingnored)
     ValidFlags valid_flags;
@@ -902,19 +823,19 @@ struct MagneticField
     
     auto as_tuple() const
     {
-        return std::make_tuple(time,sensor_id,magnetic_field,uncertainty,valid_flags);
+        return std::make_tuple(time,frame_id,magnetic_field,uncertainty,valid_flags);
     }
     
     auto as_tuple()
     {
-        return std::make_tuple(std::ref(time),std::ref(sensor_id),std::ref(magnetic_field),std::ref(uncertainty),std::ref(valid_flags));
+        return std::make_tuple(std::ref(time),std::ref(frame_id),std::ref(magnetic_field),std::ref(uncertainty),std::ref(valid_flags));
     }
     typedef void Response;
 };
 void insert(Serializer& serializer, const MagneticField& self);
 void extract(Serializer& serializer, MagneticField& self);
 
-TypedResult<MagneticField> magneticField(C::mip_interface& device, const Time& time, uint8_t sensorId, const float* magneticField, const float* uncertainty, MagneticField::ValidFlags validFlags);
+TypedResult<MagneticField> magneticField(C::mip_interface& device, const Time& time, uint8_t frameId, const float* magneticField, const float* uncertainty, MagneticField::ValidFlags validFlags);
 
 ///@}
 ///


### PR DESCRIPTION
Removes Sensor Frame Mapping command and renames "sensor_id" to "frame_id" in external aiding command set.