### PR TITLE
Fixed serial port read fail for Windows

### DIFF
--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -387,6 +387,11 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
 
 uint32_t serial_port_read_count(serial_port *port)
 {
+#ifdef WIN32 //Windows
+    // Clear the last error, if any
+    SetLastError(0);
+#endif
+
     //Check for a valid port handle
     if(!serial_port_is_open(port))
         return 0;

--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -176,14 +176,14 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
     }
 
 #else //Linux
-    
+
 #ifdef __APPLE__
     port->handle = open(port_str, O_RDWR | O_NOCTTY | O_NDELAY);
 #else
     port->handle = open(port_str, O_RDWR | O_NOCTTY | O_SYNC);
 #endif
-    
-    
+
+
     if (port->handle < 0)
     {
         MIP_LOG_ERROR("Unable to open port (%d): %s\n", errno, strerror(errno));
@@ -237,7 +237,7 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
 
 #ifdef __APPLE__
     speed_t speed = baudrate;
-    if (ioctl(port->handle, IOSSIOSPEED, &speed) < 0) 
+    if (ioctl(port->handle, IOSSIOSPEED, &speed) < 0)
     {
         MIP_LOG_ERROR("Unable to set baud rate (%d): %s\n", errno, strerror(errno));
         close(port->handle);
@@ -317,6 +317,14 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
     uint32_t bytes_available = serial_port_read_count(port);
 
 #ifdef WIN32 //Windows
+
+    DWORD last_error = GetLastError();
+    if (last_error != 0)
+    {
+        MIP_LOG_ERROR("Failed to read serial port. Error: %lx\n", last_error);
+        serial_port_close(port);
+        return false;
+    }
 
     if( wait_time <= 0 )
     {


### PR DESCRIPTION
On read fail (unplug), serial port is closed
