### PR TITLE
Fix windows build by using ifdef _WIN32

### DIFF
--- a/examples/example_utils.cpp
+++ b/examples/example_utils.cpp
@@ -8,7 +8,7 @@
 #include "example_utils.hpp"
 
 
-#ifdef WIN32
+#ifdef _WIN32
     #define PORT_KEY "COM"
 #else
     #define PORT_KEY "/dev/"

--- a/examples/watch_imu.c
+++ b/examples/watch_imu.c
@@ -23,7 +23,7 @@
 #include <stdarg.h>
 #include <inttypes.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #else
 #include <unistd.h>
 #include <fcntl.h>
@@ -228,7 +228,7 @@ int main(int argc, const char* argv[])
     // Process data for 3 seconds.
     for(unsigned int i=0; i<30; i++)
     {
-#ifdef WIN32
+#ifdef _WIN32
 #else
         usleep(100000);
 #endif

--- a/src/mip/utils/serial_port.c
+++ b/src/mip/utils/serial_port.c
@@ -76,7 +76,7 @@ bool serial_port_open(serial_port *port, const char *port_str, int baudrate)
         return false;
 
     MIP_LOG_DEBUG("Opening serial port %s at %d\n", port_str, baudrate);
-#ifdef WIN32
+#ifdef _WIN32
     BOOL   ready;
     DCB    dcb;
 
@@ -260,7 +260,7 @@ bool serial_port_close(serial_port *port)
     if(!serial_port_is_open(port))
         return false;
 
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
     //Close the serial port
     CloseHandle(port->handle);
 #else //Linux & Mac
@@ -280,7 +280,7 @@ bool serial_port_write(serial_port *port, const void *buffer, size_t num_bytes, 
     if(!serial_port_is_open(port))
         return false;
 
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
     DWORD  local_bytes_written;
 
     //Call the windows write function
@@ -314,7 +314,7 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
     if(!serial_port_is_open(port))
         return false;
 
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
 
     uint32_t bytes_available = serial_port_read_count(port);
 
@@ -387,7 +387,7 @@ bool serial_port_read(serial_port *port, void *buffer, size_t num_bytes, int wai
 
 uint32_t serial_port_read_count(serial_port *port)
 {
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
     // Clear the last error, if any
     SetLastError(0);
 #endif
@@ -396,7 +396,7 @@ uint32_t serial_port_read_count(serial_port *port)
     if(!serial_port_is_open(port))
         return 0;
 
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
     COMSTAT com_status;
     DWORD   errors;
 
@@ -418,7 +418,7 @@ uint32_t serial_port_read_count(serial_port *port)
 
 bool serial_port_is_open(const serial_port *port)
 {
-#ifdef WIN32
+#ifdef _WIN32
     return port->handle != INVALID_HANDLE_VALUE;
 #else
     return port->handle >= 0;

--- a/src/mip/utils/serial_port.h
+++ b/src/mip/utils/serial_port.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -39,7 +39,7 @@ extern "C" {
 
 typedef struct serial_port
 {
-#ifdef WIN32 //Windows
+#ifdef _WIN32 //Windows
     HANDLE handle;
 #else //Linux
     int handle;

--- a/src/mip/utils/tcp_socket.c
+++ b/src/mip/utils/tcp_socket.c
@@ -68,7 +68,7 @@ static bool tcp_socket_open_common(tcp_socket* socket_ptr, const char* hostname,
         if( connect(socket_ptr->handle, addr->ai_addr, addr->ai_addrlen) == 0 )
             break;
 
-#ifdef WIN32
+#ifdef _WIN32
         closesocket(socket_ptr->handle);
 #else
         close(socket_ptr->handle);
@@ -81,7 +81,7 @@ static bool tcp_socket_open_common(tcp_socket* socket_ptr, const char* hostname,
     if( socket_ptr->handle == INVALID_SOCKET )
         return false;
 
-#ifdef WIN32
+#ifdef _WIN32
     if( setsockopt(socket_ptr->handle, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout_ms, sizeof(timeout_ms)) != 0 )
         return false;
 
@@ -104,7 +104,7 @@ static bool tcp_socket_open_common(tcp_socket* socket_ptr, const char* hostname,
 
 bool tcp_socket_open(tcp_socket* socket_ptr, const char* hostname, uint16_t port, unsigned int timeout_ms)
 {
-#ifdef WIN32
+#ifdef _WIN32
 
     // Initialize winsock for each connection since there's no global init function.
     // This is safe to do multiple times, as long as it's shutdown the same number of times.
@@ -126,7 +126,7 @@ bool tcp_socket_close(tcp_socket* socket_ptr)
     if( socket_ptr->handle == INVALID_SOCKET )
         return false;
 
-#ifdef WIN32
+#ifdef _WIN32
     closesocket(socket_ptr->handle);
     WSACleanup(); // See tcp_socket_open
 #else
@@ -156,7 +156,7 @@ bool tcp_socket_recv(tcp_socket* socket_ptr, void* buffer, size_t num_bytes, siz
 
     if( local_bytes_read < 0 )
     {
-#ifdef WIN32
+#ifdef _WIN32
         return false;
 #else
         if(errno != EAGAIN && errno != EWOULDBLOCK)

--- a/src/mip/utils/tcp_socket.h
+++ b/src/mip/utils/tcp_socket.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -32,7 +32,7 @@ extern "C" {
 
 typedef struct tcp_socket
 {
-#ifdef WIN32
+#ifdef _WIN32
     SOCKET handle;
 #else
     int handle;


### PR DESCRIPTION
This fixes building on Windows by using the correct preprocessor direction `_WIN32`. The source files previously had a mixture of `ifdef _WIN32` (correct) and `ifdef WIN32` (incorrect). In `CMakeFiles.txt`, `if (WIN32)` is correct and is working fine.