### PR TITLE
Tweak: make Span copyable/movable

### DIFF
--- a/src/cpp/microstrain/common/span.hpp
+++ b/src/cpp/microstrain/common/span.hpp
@@ -38,7 +38,7 @@ struct Span
     using const_pointer = const T*;
     using const_reference = const T&;
 
-    Span(pointer ptr) : m_ptr(ptr) {}
+    constexpr Span(pointer ptr) : m_ptr(ptr) {}
 
     constexpr pointer begin() const noexcept { return m_ptr; }
     constexpr pointer end() const noexcept { return m_ptr+extent; }
@@ -60,7 +60,7 @@ struct Span
     [[nodiscard]] constexpr Span<T, Count == DYNAMIC_EXTENT ? DYNAMIC_EXTENT : Extent-Count> subspan() const { return {m_ptr+Offset}; }
 
 private:
-    const pointer m_ptr = nullptr;
+    pointer m_ptr = nullptr;
 };
 
 
@@ -100,8 +100,8 @@ struct Span<T, DYNAMIC_EXTENT>
     [[nodiscard]] constexpr Span<T, Count> subspan() const { return {m_ptr+Offset, Count}; }
 
 private:
-    pointer const m_ptr   = nullptr;
-    size_t  const m_cnt = 0;
+    pointer m_ptr   = nullptr;
+    size_t  m_cnt = 0;
 };
 
 


### PR DESCRIPTION
microstrain::Span declares its data pointer and count (if dynamic) as const, causing the implicit operator= to be deleted. Making these non-const would make Span copyable and movable.