### PR TITLE
Fixed UBlox parser bug

### DIFF
--- a/examples/CV7_INS/CV7_INS_simple_ublox_example.cpp
+++ b/examples/CV7_INS/CV7_INS_simple_ublox_example.cpp
@@ -311,7 +311,7 @@ int main(int argc, const char* argv[])
 
         // Check if measurement update is valid to send
         mip::Timestamp elapsed_time_from_last_measurement_update = current_timestamp - prev_measurement_update_timestamp;
-        bool ublox_data_valid = pvt_message_valid && pvt_message.time_valid && pvt_message.llh_position_valid;
+        bool ublox_data_valid = pvt_message_valid && pvt_message.time_valid && pvt_message.fix_valid;
         bool send_measurement_update = ublox_data_valid && elapsed_time_from_last_measurement_update > 250; // Cap maximum GNSS measurement input rate to 4hz
 
         if (send_measurement_update)

--- a/examples/CV7_INS/ublox_device.hpp
+++ b/examples/CV7_INS/ublox_device.hpp
@@ -87,7 +87,7 @@ namespace mip
             double longitude = 0;
             double height_above_ellipsoid = 0;
             float llh_position_uncertainty[3] = {0, 0, 0};
-            bool llh_position_valid = false;
+            bool fix_valid = false;
 
             // NED velocity
             float ned_velocity[3] = {0, 0, 0};
@@ -118,7 +118,7 @@ namespace mip
             ublox_message.llh_position_uncertainty[0] = float(ublox_message_raw.horizontal_accuracy) * 1e-3f;
             ublox_message.llh_position_uncertainty[1] = float(ublox_message_raw.horizontal_accuracy) * 1e-3f;
             ublox_message.llh_position_uncertainty[2] = float(ublox_message_raw.vertical_accuracy) * 1e-3f;
-            ublox_message.llh_position_valid = !ublox_message_raw.llh_invalid_flag;
+            ublox_message.fix_valid = ublox_message_raw.fix_type >= 3;
 
             // NED velocity
             ublox_message.ned_velocity[0] = float(ublox_message_raw.north_velocity) * 1e-3f;


### PR DESCRIPTION
Ublox parser was using the wrong field to identify a valid 3D fix, causing the CV7-INS to initialize with an invalid fix (all zeros)