### PR TITLE
Fix packet writing field issue.

### DIFF
--- a/src/cpp/mip/mip_packet.hpp
+++ b/src/cpp/mip/mip_packet.hpp
@@ -124,7 +124,7 @@ public:
             if(ok)
                 ok &= C::mip_packet_update_last_field_length(&m_packet, basePointer(), (uint8_t) usedLength()) >= 0;
 
-            if(!ok)
+            if(!ok && basePointer())
                 C::mip_packet_cancel_last_field(&m_packet, basePointer());
 
             return ok;


### PR DESCRIPTION
Adding field to packet caused assert if the field was too large to fit and it failed to allocate space due to a null pointer.  The null pointer was then referenced when trying to rollback the insertion but failed because there was nothing to rollback.  Validating the pointer in the rollback case.