### PR TITLE
Fix v2.0.0 INSTALL_INTERFACE path to avoid referencing a non-existent 'src' folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ add_library(mip ${ALL_MIP_SOURCES})
 
 target_include_directories(mip PUBLIC
   "$<BUILD_INTERFACE:${SRC_DIR}>" # Include directory for build only
-  "$<INSTALL_INTERFACE:src>"      # Include directory for installation
+  "$<INSTALL_INTERFACE:include>"      # Include directory for installation
 )
 
 if(WITH_INTERNAL)


### PR DESCRIPTION
### Summary of the Problem for v2.0.0

When installing the MIP SDK, the generated CMake configuration references a path that does not actually exist after installation. Specifically, in the `target_include_directories(mip ...)` call, `"$<INSTALL_INTERFACE:src>"` is used. This causes the installed **`mip-targets.cmake`** (or `mip-config.cmake`) to include a path such as:
```
INTERFACE_INCLUDE_DIRECTORIES "/home/user/mip_sdk/install/src"
```
However, the actual headers are installed into the `include/` directory, not `src/`, so this path is invalid. This leads to CMake errors in downstream projects, for example:
```cmake
CMake Error in src/CMakeLists.txt: Imported target "mip" includes non-existent path "/home/user/mip_sdk/install/src" in its INTERFACE_INCLUDE_DIRECTORIES.
```
### What This Fix Changes

I replaced:

```cmake
target_include_directories(mip PUBLIC
  "$<BUILD_INTERFACE:${SRC_DIR}>"
  "$<INSTALL_INTERFACE:src>"
)
```
After running make install, the configuration file will now reference:
```
INTERFACE_INCLUDE_DIRECTORIES "/home/user/mip_sdk/install/include"
```
which actually exists and contains the SDK’s header files.

### Verification
1. Local Build & Install
```bash
mkdir build && cd build
cmake -DCMAKE_INSTALL_PREFIX=/home/user/mip_sdk/install ..
make -j4
make install
```
* Checked the resulting mip-targets.cmake: it now points to /home/user/mip_sdk/install/include instead of /home/user/mip_sdk/install/src.
2. Downstream Test

* Created a minimal CMake project that does find_package(mip REQUIRED) and then links against the mip library.
* No more errors about non-existent install/src directories.

Thank you for reviewing this PR! If you have any questions or suggestions, please let me know, and I’ll be happy to update the changes.