### PR TITLE
Restore mip_interface_recv_from_device

### DIFF
--- a/examples/CV7/CV7_example.c
+++ b/examples/CV7/CV7_example.c
@@ -27,23 +27,19 @@
 // Include Files
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "example_utils.h"
+
 #include <mip/mip_all.h>
 #include <microstrain/connections/serial/serial_port.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 
-#include "example_utils.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global Variables
 ////////////////////////////////////////////////////////////////////////////////
 
-serial_port device_port;
-clock_t start_time;
-
 int port = -1;
-uint8_t parse_buffer[1024];
 mip_interface device;
 
 //Sensor-to-vehicle frame transformation (Euler Angles)
@@ -69,16 +65,7 @@ const uint8_t FILTER_PITCH_EVENT_ACTION_ID = 2;
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
 
-
-//Required MIP interface user-defined functions
-mip_timestamp get_current_timestamp();
-
-bool mip_interface_user_recv_from_device(mip_interface* device_, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
-bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length);
-
 int usage(const char* argv0);
-
-void exit_gracefully(const char *message);
 bool should_exit();
 
 void handle_filter_event_source(void* user, const mip_field_view* field, mip_timestamp timestamp);
@@ -105,11 +92,7 @@ int main(int argc, const char* argv[])
     if(baudrate == 0)
         return usage(argv[0]);
 
-    //
-    //Get the program start time
-    //
-
-    start_time = clock();
+    mip_example_init();
 
     printf("Connecting to and configuring sensor.\n");
 
@@ -376,53 +359,6 @@ void handle_filter_event_source(void* user, const mip_field_view* field, mip_tim
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// MIP Interface Time Access Function
-////////////////////////////////////////////////////////////////////////////////
-
-mip_timestamp get_current_timestamp()
-{
-    clock_t curr_time;
-    curr_time = clock();
-
-    return (mip_timestamp)((double)(curr_time - start_time) / (double)CLOCKS_PER_SEC * 1000.0);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Recv Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_recv_from_device(mip_interface* device_, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out)
-{
-    (void)device_;
-
-    *timestamp_out = get_current_timestamp();
-
-    size_t length;
-
-    if( !serial_port_read(&device_port, parse_buffer, sizeof(parse_buffer), (int)wait_time, &length) )
-        return false;
-
-    mip_interface_input_bytes(device_, parse_buffer, length, *timestamp_out);
-    return true;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Send Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length)
-{
-    (void)device_;
-
-    size_t bytes_written;
-
-    return serial_port_write(&device_port, data, length, &bytes_written);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 // Print Usage Function
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -430,27 +366,6 @@ int usage(const char* argv0)
 {
     printf("Usage: %s <port> <baudrate>\n", argv0);
     return 1;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Exit Function
-////////////////////////////////////////////////////////////////////////////////
-
-void exit_gracefully(const char *message)
-{
-    if(message)
-        printf("%s\n", message);
-
-    //Close com port
-    if(serial_port_is_open(&device_port))
-        serial_port_close(&device_port);
-
-#ifdef MICROSTRAIN_PLATFORM_WINDOWS
-    getchar();
-#endif
-
-    exit(0);
 }
 
 

--- a/examples/CX5_GX5_45/CX5_GX5_45_example.c
+++ b/examples/CX5_GX5_45/CX5_GX5_45_example.c
@@ -27,24 +27,19 @@
 // Include Files
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "example_utils.h"
+
 #include <mip/mip_all.h>
 #include <microstrain/connections/serial/serial_port.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
-#include <time.h>
 
-//#include "example_utils.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global Variables
 ////////////////////////////////////////////////////////////////////////////////
 
-serial_port device_port;
-clock_t start_time;
-
 int port = -1;
-uint8_t parse_buffer[1024];
 mip_interface device;
 
 //Sensor-to-vehicle frame rotation (Euler Angles)
@@ -76,16 +71,7 @@ bool filter_state_running = false;
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
 
-
-//Required MIP interface user-defined functions
-mip_timestamp get_current_timestamp();
-
-bool mip_interface_user_recv_from_device(mip_interface* device, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
-bool mip_interface_user_send_to_device(mip_interface* device, const uint8_t* data, size_t length);
-
 int usage(const char* argv0);
-
-void exit_gracefully(const char *message);
 bool should_exit();
 
 
@@ -110,11 +96,7 @@ int main(int argc, const char* argv[])
     if(baudrate == 0)
         return usage(argv[0]);
 
-    //
-    //Get the program start time
-    //
-
-    start_time = clock();
+    mip_example_init();
 
     printf("Connecting to and configuring sensor.\n");
 
@@ -351,53 +333,6 @@ int main(int argc, const char* argv[])
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// MIP Interface Time Access Function
-////////////////////////////////////////////////////////////////////////////////
-
-mip_timestamp get_current_timestamp()
-{
-    clock_t curr_time;
-    curr_time = clock();
-
-    return (mip_timestamp)((double)(curr_time - start_time) / (double)CLOCKS_PER_SEC * 1000.0);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Recv Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_recv_from_device(mip_interface* device_, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out)
-{
-    (void)device_;
-
-    *timestamp_out = get_current_timestamp();
-
-    size_t length;
-
-    if( !serial_port_read(&device_port, parse_buffer, sizeof(parse_buffer), (int)wait_time, &length) )
-        return false;
-
-    mip_interface_input_bytes(device_, parse_buffer, length, *timestamp_out);
-    return true;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Send Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length)
-{
-    (void)device_;
-
-    size_t bytes_written;
-
-    return serial_port_write(&device_port, data, length, &bytes_written);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 // Print Usage Function
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -405,27 +340,6 @@ int usage(const char* argv0)
 {
     printf("Usage: %s <port> <baudrate>\n", argv0);
     return 1;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Exit Function
-////////////////////////////////////////////////////////////////////////////////
-
-void exit_gracefully(const char *message)
-{
-    if(message)
-        printf("%s\n", message);
-
-    //Close com port
-    if(serial_port_is_open(&device_port))
-        serial_port_close(&device_port);
-
-#ifdef MICROSTRAIN_PLATFORM_WINDOWS
-    getchar();
-#endif
-
-    exit(0);
 }
 
 

--- a/examples/CX5_GX5_CV5_15_25/CX5_GX5_CV5_15_25_example.c
+++ b/examples/CX5_GX5_CV5_15_25/CX5_GX5_CV5_15_25_example.c
@@ -27,25 +27,19 @@
 // Include Files
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "example_utils.h"
+
 #include <mip/mip_all.h>
 #include <microstrain/connections/serial/serial_port.h>
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
-#include <time.h>
-
-//#include "example_utils.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global Variables
 ////////////////////////////////////////////////////////////////////////////////
 
-serial_port device_port;
-clock_t start_time;
-
 int port = -1;
-uint8_t parse_buffer[1024];
 mip_interface device;
 
 //Sensor-to-vehicle frame rotation (Euler Angles)
@@ -69,16 +63,7 @@ bool filter_state_running = false;
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
 
-
-//Required MIP interface user-defined functions
-mip_timestamp get_current_timestamp();
-
-bool mip_interface_user_recv_from_device(mip_interface* device, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
-bool mip_interface_user_send_to_device(mip_interface* device, const uint8_t* data, size_t length);
-
 int usage(const char* argv0);
-
-void exit_gracefully(const char *message);
 bool should_exit();
 
 
@@ -103,11 +88,7 @@ int main(int argc, const char* argv[])
     if(baudrate == 0)
         return usage(argv[0]);
 
-    //
-    //Get the program start time
-    //
-
-    start_time = clock();
+    mip_example_init();
 
     printf("Connecting to and configuring sensor.\n");
 
@@ -301,53 +282,6 @@ int main(int argc, const char* argv[])
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// MIP Interface Time Access Function
-////////////////////////////////////////////////////////////////////////////////
-
-mip_timestamp get_current_timestamp()
-{
-    clock_t curr_time;
-    curr_time = clock();
-
-    return (mip_timestamp)((double)(curr_time - start_time)/(double)CLOCKS_PER_SEC*1000.0);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Recv Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_recv_from_device(mip_interface* device_, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out)
-{
-    (void)device_;
-
-    *timestamp_out = get_current_timestamp();
-
-    size_t length;
-
-    if( !serial_port_read(&device_port, parse_buffer, sizeof(parse_buffer), (int)wait_time, &length) )
-        return false;
-
-    mip_interface_input_bytes(device_, parse_buffer, length, *timestamp_out);
-    return true;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Send Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length)
-{
-    (void)device_;
-
-    size_t bytes_written;
-
-    return serial_port_write(&device_port, data, length, &bytes_written);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
 // Print Usage Function
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -355,27 +289,6 @@ int usage(const char* argv0)
 {
     printf("Usage: %s <port> <baudrate>\n", argv0);
     return 1;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Exit Function
-////////////////////////////////////////////////////////////////////////////////
-
-void exit_gracefully(const char *message)
-{
-    if(message)
-        printf("%s\n", message);
-
-    //Close com port
-    if(serial_port_is_open(&device_port))
-        serial_port_close(&device_port);
-
-#ifdef MICROSTRAIN_PLATFORM_WINDOWS
-    getchar();
-#endif
-
-    exit(0);
 }
 
 

--- a/examples/GQ7/GQ7_example.c
+++ b/examples/GQ7/GQ7_example.c
@@ -27,25 +27,19 @@
 // Include Files
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "example_utils.h"
+
 #include <mip/mip_all.h>
 #include <microstrain/connections/serial/serial_port.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
-#include <time.h>
-
-#include "example_utils.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // Global Variables
 ////////////////////////////////////////////////////////////////////////////////
 
-serial_port device_port;
-clock_t start_time;
-
 int port = -1;
-uint8_t parse_buffer[1024];
 mip_interface device;
 
 //Sensor-to-vehicle frame transformation (Euler Angles)
@@ -78,16 +72,7 @@ bool filter_state_full_nav = false;
 // Function Prototypes
 ////////////////////////////////////////////////////////////////////////////////
 
-
-//Required MIP interface user-defined functions
-mip_timestamp get_current_timestamp();
-
-bool mip_interface_user_recv_from_device(mip_interface* device, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
-bool mip_interface_user_send_to_device(mip_interface* device, const uint8_t* data, size_t length);
-
 int usage(const char* argv0);
-
-void exit_gracefully(const char *message);
 bool should_exit();
 
 
@@ -112,11 +97,7 @@ int main(int argc, const char* argv[])
     if(baudrate == 0)
         return usage(argv[0]);
 
-    //
-    //Get the program start time
-    //
-
-    start_time = clock();
+    mip_example_init();
 
     printf("Connecting to and configuring sensor.\n");
 
@@ -383,54 +364,6 @@ int main(int argc, const char* argv[])
     exit_gracefully("Example Completed Successfully.");
 }
 
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface Time Access Function
-////////////////////////////////////////////////////////////////////////////////
-
-mip_timestamp get_current_timestamp()
-{
-    clock_t curr_time;
-    curr_time = clock();
-
-    return (mip_timestamp)((double)(curr_time - start_time) / (double)CLOCKS_PER_SEC * 1000.0);
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Recv Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_recv_from_device(mip_interface* device_, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out)
-{
-    (void)from_cmd;
-
-    *timestamp_out = get_current_timestamp();
-
-    size_t length;
-
-    if( !serial_port_read(&device_port, parse_buffer, sizeof(parse_buffer), (int)wait_time, &length) )
-        return false;
-
-    mip_interface_input_bytes(device_, parse_buffer, length, *timestamp_out);
-    return true;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// MIP Interface User Send Data Function
-////////////////////////////////////////////////////////////////////////////////
-
-bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length)
-{
-    (void)device_;
-
-    size_t bytes_written;
-
-    return serial_port_write(&device_port, data, length, &bytes_written);
-}
-
-
 ////////////////////////////////////////////////////////////////////////////////
 // Print Usage Function
 ////////////////////////////////////////////////////////////////////////////////
@@ -439,27 +372,6 @@ int usage(const char* argv0)
 {
     printf("Usage: %s <port> <baudrate>\n", argv0);
     return 1;
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-// Exit Function
-////////////////////////////////////////////////////////////////////////////////
-
-void exit_gracefully(const char *message)
-{
-    if(message)
-        printf("%s\n", message);
-
-    //Close com port
-    if(serial_port_is_open(&device_port))
-        serial_port_close(&device_port);
-
-#ifdef MICROSTRAIN_PLATFORM_WINDOWS
-    getchar();
-#endif
-
-    exit(0);
 }
 
 

--- a/examples/example_utils.c
+++ b/examples/example_utils.c
@@ -2,8 +2,95 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+#include <stdlib.h>
 
-void displayFilterState(const mip_filter_mode filter_state, char **current_state, bool isFiveSeries) 
+
+serial_port device_port;
+time_t startTime;
+
+
+void mip_example_init()
+{
+    serial_port_init(&device_port);
+
+    // Record program start time for use with difftime in getTimestamp().
+    time(&startTime);
+
+    // Initialize the MIP logger before opening the port so we can print errors if they occur
+    MICROSTRAIN_LOG_INIT(&mip_example_log, MICROSTRAIN_LOG_LEVEL_INFO, NULL);
+}
+
+
+void mip_example_log(void* user, microstrain_log_level level, const char* fmt, va_list args)
+{
+    (void)user;
+
+    switch (level)
+    {
+    case MICROSTRAIN_LOG_LEVEL_FATAL:
+    case MICROSTRAIN_LOG_LEVEL_ERROR:
+        vfprintf(stderr, fmt, args);
+        break;
+    default:
+        vprintf(fmt, args);
+        break;
+    }
+}
+
+
+mip_timestamp get_current_timestamp()
+{
+    time_t t;
+    time(&t);
+
+    double delta = difftime(t, startTime);
+
+    return (mip_timestamp)(delta * 1000);
+}
+
+
+bool mip_interface_user_recv_from_device(mip_interface* device_, uint8_t* buffer, size_t max_length, mip_timeout wait_time, bool from_cmd, size_t* length_out, mip_timestamp* timestamp_out)
+{
+    (void)device_;
+    (void)from_cmd;
+
+    *timestamp_out = get_current_timestamp();
+
+    return serial_port_read(&device_port, buffer, max_length, (int)wait_time, length_out);
+}
+
+
+bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length)
+{
+    (void)device_;
+
+    size_t bytes_written;
+    if (!serial_port_write(&device_port, data, length, &bytes_written))
+        return false;
+
+    return true;
+}
+
+
+void exit_gracefully(const char *message)
+{
+    if(message)
+        printf("%s\n", message);
+
+    // Close com port
+    if(serial_port_is_open(&device_port))
+        serial_port_close(&device_port);
+
+#ifdef MICROSTRAIN_PLATFORM_WINDOWS
+    getchar();
+#endif
+
+    exit(0);
+}
+
+
+void displayFilterState(const mip_filter_mode filter_state, char **current_state, bool isFiveSeries)
 {
     char *read_state = "";
     if (filter_state == MIP_FILTER_MODE_INIT)
@@ -17,7 +104,7 @@ void displayFilterState(const mip_filter_mode filter_state, char **current_state
     else
         read_state = "STARTUP (0)";
 
-    if (strcmp(read_state, *current_state) != 0) 
+    if (strcmp(read_state, *current_state) != 0)
     {
         printf("FILTER STATE: %s\n", read_state);
         *current_state = read_state;

--- a/examples/example_utils.h
+++ b/examples/example_utils.h
@@ -1,5 +1,19 @@
+#pragma once
+
 #include <mip/definitions/data_filter.h>
 
+#include <microstrain/connections/serial/serial_port.h>
+#include <microstrain/common/logging.h>
+
+extern serial_port device_port;
+
+void mip_example_init();
+void mip_example_log(void* user, microstrain_log_level level, const char* fmt, va_list args);
+mip_timestamp get_current_timestamp();
+bool mip_interface_user_recv_from_device(mip_interface* device_, uint8_t* buffer, size_t max_length, mip_timeout wait_time, bool from_cmd, size_t* length_out, mip_timestamp* timestamp_out);
+bool mip_interface_user_send_to_device(mip_interface* device_, const uint8_t* data, size_t length);
+
+void exit_gracefully(const char *message);
 
 // Displays current filter state for the connected device if it has changed.
 void displayFilterState(const mip_filter_mode filterState, char **currentState, bool isFiveSeries);

--- a/examples/threading.cpp
+++ b/examples/threading.cpp
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[])
 #if USE_THREADS
         // Set the update function. Before this call, command replies are processed by the main thread.
         // After this, replies will be processed by the device thread.
-        device->setUpdateFunction<&update_device>();
+        device->setUpdateFunctionFree<&update_device>();
 
         // Start the device thread.
         std::thread deviceThread( &device_thread_loop, device.get() );

--- a/src/c/mip/mip_interface.c
+++ b/src/c/mip/mip_interface.c
@@ -415,7 +415,7 @@ bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, 
     if ( !(device->_recv_callback)(device, buffer, sizeof(buffer), wait_time, from_cmd, &count, &timestamp) )
         return false;
 
-    mip_interface_input_data_and_time(device, buffer, count, timestamp);
+    mip_interface_input_bytes_andor_time(device, buffer, count, timestamp);
 
     return true;
 }
@@ -429,13 +429,13 @@ bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, 
 ///@li Input bytes to the parser, via mip_interface_input_bytes_from_device, and
 ///@li Update the current time via mip_interface_update_time
 ///
-void mip_interface_input_data_and_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp timestamp)
+void mip_interface_input_bytes_andor_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp now)
 {
     // Pass the data to the MIP parser.
-    mip_interface_input_bytes_from_device(device, received_data, data_length, timestamp);
+    mip_interface_input_bytes_from_device(device, received_data, data_length, now);
 
     // Update the command queue to see if any commands have timed out.
-    mip_interface_update_time(device, timestamp);
+    mip_interface_update_time(device, now);
 }
 
 

--- a/src/c/mip/mip_interface.h
+++ b/src/c/mip/mip_interface.h
@@ -69,7 +69,7 @@ bool mip_interface_recv_from_device(mip_interface* device, uint8_t* buffer, size
 bool mip_interface_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
 bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
-void mip_interface_input_data_and_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp now);
+void mip_interface_input_bytes_andor_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp now);
 
 void mip_interface_input_bytes_from_device(mip_interface* device, const uint8_t* data, size_t length, mip_timestamp timestamp);
 void mip_interface_input_packet_from_device(mip_interface* device, const mip_packet_view* packet, mip_timestamp timestamp);

--- a/src/c/mip/mip_interface.h
+++ b/src/c/mip/mip_interface.h
@@ -69,6 +69,7 @@ bool mip_interface_recv_from_device(mip_interface* device, uint8_t* buffer, size
 bool mip_interface_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
 bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
+bool mip_interface_default_update_ext_buffer(mip_interface* device, mip_timeout wait_time, bool from_cmd, uint8_t* buffer, size_t buffer_size);
 void mip_interface_input_bytes_andor_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp now);
 
 void mip_interface_input_bytes_from_device(mip_interface* device, const uint8_t* data, size_t length, mip_timestamp timestamp);

--- a/src/c/mip/mip_interface.h
+++ b/src/c/mip/mip_interface.h
@@ -34,7 +34,7 @@ struct mip_interface;
 
 // Documentation is in source file.
 typedef bool (*mip_send_callback)(struct mip_interface* device, const uint8_t* data, size_t length);
-typedef bool (*mip_recv_callback)(struct mip_interface* device, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
+typedef bool (*mip_recv_callback)(struct mip_interface* device, uint8_t* buffer, size_t max_length, mip_timeout wait_time, bool from_cmd, size_t* length_out, mip_timestamp* timestamp_out);
 typedef bool (*mip_update_callback)(struct mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
 
@@ -66,13 +66,13 @@ void mip_interface_init(
 //
 
 bool mip_interface_send_to_device(mip_interface* device, const uint8_t* data, size_t length);
-bool mip_interface_recv_from_device(mip_interface* device, mip_timeout wait_time, bool from_cmd, mip_timestamp* timestamp_out);
+bool mip_interface_recv_from_device(mip_interface* device, uint8_t* buffer, size_t max_length, mip_timeout wait_time, bool from_cmd, size_t* length_out, mip_timestamp* timestamp_out);
 bool mip_interface_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
 bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
-void mip_interface_input_bytes(mip_interface* device, const uint8_t* data, size_t length, mip_timestamp timestamp);
-void mip_interface_input_packet(mip_interface* device, const mip_packet_view* packet, mip_timestamp timestamp);
+void mip_interface_input_bytes_from_device(mip_interface* device, const uint8_t* data, size_t length, mip_timestamp timestamp);
+void mip_interface_input_packet_from_device(mip_interface* device, const mip_packet_view* packet, mip_timestamp timestamp);
 
 void mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp);
 

--- a/src/c/mip/mip_interface.h
+++ b/src/c/mip/mip_interface.h
@@ -46,7 +46,6 @@ typedef struct mip_interface
     mip_parser          _parser;          ///<@private MIP Parser for incoming MIP packets.
     mip_cmd_queue       _queue;           ///<@private Queue for checking command replies.
     mip_dispatcher      _dispatcher;      ///<@private Dispatcher for data callbacks.
-    //unsigned int        _max_update_pkts; ///<@private Max number of MIP packets to parse at once.
     mip_send_callback   _send_callback;   ///<@private Optional function which is called to send raw bytes to the device.
     mip_recv_callback   _recv_callback;   ///<@private Optional function which is called to receive raw bytes from the device.
     mip_update_callback _update_callback; ///<@private Optional function to call during updates.
@@ -70,9 +69,11 @@ bool mip_interface_recv_from_device(mip_interface* device, uint8_t* buffer, size
 bool mip_interface_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
 
 bool mip_interface_default_update(mip_interface* device, mip_timeout wait_time, bool from_cmd);
+void mip_interface_input_data_and_time(mip_interface* device, const uint8_t* received_data, size_t data_length, mip_timestamp now);
 
 void mip_interface_input_bytes_from_device(mip_interface* device, const uint8_t* data, size_t length, mip_timestamp timestamp);
 void mip_interface_input_packet_from_device(mip_interface* device, const mip_packet_view* packet, mip_timestamp timestamp);
+void mip_interface_update_time(mip_interface* device, mip_timestamp timestamp);
 
 void mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp);
 

--- a/src/cpp/microstrain/common/span.hpp
+++ b/src/cpp/microstrain/common/span.hpp
@@ -78,6 +78,14 @@ struct Span
     template<size_t Offset, size_t Count = DYNAMIC_EXTENT>
     [[nodiscard]] constexpr Span<T, Count == DYNAMIC_EXTENT ? DYNAMIC_EXTENT : Extent-Count> subspan() const { return {m_ptr+Offset}; }
 
+    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> first(size_t count) const { return {m_ptr, count};}
+    template<size_t Count>
+    [[nodiscard]] constexpr Span<T, Count> first() const { static_assert(Count<=Extent, "Count out of range"); return {m_ptr}; }
+
+    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> last(size_t count) const { return {m_ptr+(size()-count), count};}
+    template<size_t Count>
+    [[nodiscard]] constexpr Span<T, Count> last() const { static_assert(Count<=Extent, "Count out of range"); return {m_ptr+(size()-count)}; }
+
 private:
     pointer m_ptr = nullptr;
 };
@@ -117,6 +125,14 @@ struct Span<T, DYNAMIC_EXTENT>
     [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> subspan(size_t index) const { return {m_ptr+index, m_cnt-index}; }
     template<size_t Offset, size_t Count = DYNAMIC_EXTENT>
     [[nodiscard]] constexpr Span<T, Count> subspan() const { return {m_ptr+Offset, Count}; }
+
+    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> first(size_t count) const { return {m_ptr, count};}
+    template<size_t Count>
+    [[nodiscard]] constexpr Span<T, Count> first() const { return {m_ptr}; }
+
+    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> last(size_t count) const { return {m_ptr+(size()-count), count};}
+    template<size_t Count>
+    [[nodiscard]] constexpr Span<T, Count> last() const { return {m_ptr+(size()-count)}; }
 
 private:
     pointer m_ptr   = nullptr;

--- a/src/cpp/microstrain/common/span.hpp
+++ b/src/cpp/microstrain/common/span.hpp
@@ -57,14 +57,6 @@ struct Span
     constexpr element_type front() const noexcept { return *m_ptr; }
     constexpr element_type back() const noexcept { return *m_ptr[extent-1]; }
 
-    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> first(size_t count) const { return { m_ptr, count }; }
-    template<size_t Count>
-    [[nodiscard]] constexpr Span<T, Count> first() const { return { m_ptr }; }
-
-    [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> last(size_t count) const { return { m_ptr + (size() - count), count }; }
-    template<size_t Count>
-    [[nodiscard]] constexpr Span<T, Count> last() const { return { m_ptr + size() - Count }; }
-
     constexpr reference operator[](size_t idx) noexcept { return m_ptr[idx]; }
     constexpr const_reference operator[](size_t idx) const noexcept { return m_ptr[idx]; }
 
@@ -84,7 +76,7 @@ struct Span
 
     [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> last(size_t count) const { return {m_ptr+(size()-count), count};}
     template<size_t Count>
-    [[nodiscard]] constexpr Span<T, Count> last() const { static_assert(Count<=Extent, "Count out of range"); return {m_ptr+(size()-count)}; }
+    [[nodiscard]] constexpr Span<T, Count> last() const { static_assert(Count<=Extent, "Count out of range"); return {m_ptr+(Extent-Count)}; }
 
 private:
     pointer m_ptr = nullptr;
@@ -132,7 +124,7 @@ struct Span<T, DYNAMIC_EXTENT>
 
     [[nodiscard]] constexpr Span<T, DYNAMIC_EXTENT> last(size_t count) const { return {m_ptr+(size()-count), count};}
     template<size_t Count>
-    [[nodiscard]] constexpr Span<T, Count> last() const { return {m_ptr+(size()-count)}; }
+    [[nodiscard]] constexpr Span<T, Count> last() const { return {m_ptr+(size()-Count)}; }
 
 private:
     pointer m_ptr   = nullptr;

--- a/src/cpp/microstrain/connections/connection.hpp
+++ b/src/cpp/microstrain/connections/connection.hpp
@@ -29,8 +29,15 @@ namespace microstrain
         virtual bool sendToDevice(const uint8_t* data, size_t length) = 0;
         virtual bool recvFromDevice(uint8_t* buffer, size_t max_length, unsigned int wait_time_ms, size_t* length_out, EmbeddedTimestamp* timestamp_out) = 0;
 
-        bool sendToDevice(microstrain::Span<const uint8_t> data) { return sendToDevice(data.data(), data.size()); }
-        bool recvFromDevice(microstrain::Span<uint8_t>& buffer, unsigned int wait_time_ms, EmbeddedTimestamp* timestamp_out)
+        bool sendToDeviceSpan(microstrain::Span<const uint8_t> data) { return sendToDevice(data.data(), data.size()); }
+        bool recvFromDeviceSpan(microstrain::Span<uint8_t> buffer, unsigned int wait_time_ms, size_t* length_out, EmbeddedTimestamp* timestamp_out)
+        {
+            if (!recvFromDevice(buffer.data(), buffer.size(), wait_time_ms, length_out, timestamp_out))
+                return false;
+
+            return true;
+        }
+        bool recvFromDeviceSpanUpdate(microstrain::Span<uint8_t>& buffer, unsigned int wait_time_ms, EmbeddedTimestamp* timestamp_out)
         {
             size_t length = 0;
             if (!recvFromDevice(buffer.data(), buffer.size(), wait_time_ms, &length, timestamp_out))

--- a/src/cpp/mip/mip_interface.cpp
+++ b/src/cpp/mip/mip_interface.cpp
@@ -59,7 +59,7 @@ namespace mip
     ///
     bool recv_from_connection(Connection* conn, Span<uint8_t> buffer, Timeout timeout, bool /*from_cmd*/, size_t* length_out, Timestamp* timestamp_out)
     {
-        return conn->recvFromDeviceSpan(buffer, timeout, length_out, timestamp_out);
+        return conn->recvFromDeviceSpan(buffer, (unsigned int)timeout, length_out, timestamp_out);
     }
 
 } // namespace mip

--- a/src/cpp/mip/mip_interface.cpp
+++ b/src/cpp/mip/mip_interface.cpp
@@ -2,6 +2,10 @@
 
 #include <microstrain/connections/connection.hpp>
 
+using microstrain::Connection;
+using microstrain::Span;
+
+
 namespace mip
 {
     ////////////////////////////////////////////////////////////////////////////////
@@ -31,6 +35,7 @@ namespace mip
     ///@param timestamp_out Timestamp of when the data was received
     ////////////////////////////////////////////////////////////////////////////////
 
+
     ////////////////////////////////////////////////////////////////////////////////
     ///@brief Sets up the mip interface callbacks to point at this object.
     ///
@@ -39,29 +44,22 @@ namespace mip
     ///@param device Device to configure.
     ///@param conn   The connection to set
     ///
-    void connect_interface(mip::Interface& device, microstrain::Connection& conn)
+    void connect_interface(mip::Interface& device, Connection& conn)
     {
-        using microstrain::Connection;
+        device.setUserPointer(&conn);
 
-        C::mip_send_callback send = +[](C::mip_interface* device, const uint8_t* data, size_t length)->bool
-        {
-            return static_cast<Connection*>(C::mip_interface_user_pointer(device))->sendToDevice(data, length);
-        };
-
-        C::mip_recv_callback recv = +[](C::mip_interface* device, C::mip_timeout wait_time, bool, C::mip_timestamp* timestamp_out)->bool
-        {
-            uint8_t buffer[512];
-            size_t length;
-            if (!static_cast<Connection*>(C::mip_interface_user_pointer(device))->recvFromDevice(buffer, sizeof(buffer), static_cast<unsigned int>(wait_time), &length, timestamp_out))
-                return false;
-
-            C::mip_interface_input_bytes(device, buffer, length, *timestamp_out);
-            return true;
-        };
-
-        C::mip_interface_set_user_pointer(&device, &conn);
-
-        C::mip_interface_set_send_function(&device, send);
-        C::mip_interface_set_recv_function(&device, recv);
+        device.setSendFunctionUserPointer<Connection, &Connection::sendToDevice>();
+        device.setRecvFunctionUserPointer<Connection, &recv_from_connection>();
+        device.setUpdateFunction(C::mip_interface_default_update);
     }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    ///@brief Adapts microstrain::Connection::recvFromDeviceSpan to a signature
+    ///       compatible with mip interface receive callbacks.
+    ///
+    bool recv_from_connection(Connection* conn, Span<uint8_t> buffer, Timeout timeout, bool /*from_cmd*/, size_t* length_out, Timestamp* timestamp_out)
+    {
+        return conn->recvFromDeviceSpan(buffer, timeout, length_out, timestamp_out);
+    }
+
 } // namespace mip

--- a/src/cpp/mip/mip_interface.hpp
+++ b/src/cpp/mip/mip_interface.hpp
@@ -194,9 +194,11 @@ namespace mip
         bool update(Timeout wait_time = 0, bool from_cmd = false) { return C::mip_interface_update(this, wait_time, from_cmd); }
 
         bool defaultUpdate(Timeout wait_time = 0, bool from_cmd = false) { return C::mip_interface_default_update(this, wait_time, from_cmd); }
+        bool defaultUpdateExtBuffer(Timeout wait_time, bool from_cmd, microstrain::Span<uint8_t> buffer) { return C::mip_interface_default_update_ext_buffer(this, wait_time, from_cmd, buffer.data(), buffer.size()); }
         void inputBytes(const uint8_t* data, size_t length, Timestamp timestamp) { C::mip_interface_input_bytes_from_device(this, data, length, timestamp); }
         void inputPacket(const C::mip_packet_view& packet, Timestamp timestamp) { C::mip_interface_input_packet_from_device(this, &packet, timestamp); }
-
+        void updateTime(Timestamp timestamp) { C::mip_interface_update_time(this, timestamp); }
+        void inputBytesAndOrTime(microstrain::Span<const uint8_t> data, Timestamp timestamp) { C::mip_interface_input_bytes_andor_time(this, data.data(), data.size(), timestamp); }
 
         CmdResult waitForReply(C::mip_pending_cmd& cmd) { return C::mip_interface_wait_for_reply(this, &cmd); }
 


### PR DESCRIPTION
* Change mip_interface_recv_from_device back to taking a buffer for data.
* Improve connection-related callback binding options in C++.
* Update C examples and move some common code to example_utils.
