### PR TITLE
Some of the header files are not installed using cmake install

### DIFF
--- a/src/c/microstrain/common/CMakeLists.txt
+++ b/src/c/microstrain/common/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MICROSTRAIN_LOGGING_MAX_LEVEL "MICROSTRAIN_LOG_LEVEL_WARN" CACHE STRING "Max
 set(MICROSTRAIN_TIMESTAMP_TYPE "uint64_t" CACHE STRING "Override the type used for received data timestamps and timeouts (must be unsigned or at least 64 bits).")
 
 set(MICROSTRAIN_COMMON_SOURCES
+    "${CMAKE_CURRENT_LIST_DIR}/embedded_time.h"
     "${CMAKE_CURRENT_LIST_DIR}/logging.h"
     "${CMAKE_CURRENT_LIST_DIR}/platform.h"
     "${CMAKE_CURRENT_LIST_DIR}/serialization.c"

--- a/src/cpp/microstrain/common/CMakeLists.txt
+++ b/src/cpp/microstrain/common/CMakeLists.txt
@@ -5,6 +5,7 @@ set(MICROSTRAIN_COMMON_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/logging.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/platform.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/serialization.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/span.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/serialization/readwrite.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/serialization/serializer.hpp"
 )

--- a/src/cpp/mip/CMakeLists.txt
+++ b/src/cpp/mip/CMakeLists.txt
@@ -12,6 +12,8 @@ set(MIP_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/mip_parser.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/mip_result.hpp"
     "${CMAKE_CURRENT_LIST_DIR}/mip_serialization.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/definitions/common.hpp"
+    ${MIP_DEF_HEADERS}
 )
 
 target_sources(${MIP_LIBRARY} PRIVATE


### PR DESCRIPTION
I tried to create an application with mipsdk installed using cmake, but I found that there were some missing header files.

Changes:
- Added the missing header files to the install.

Testing:
- My application now builds with installed mipsdk.