### PR TITLE
Allow mip parser callback to stop parsing prematurely by returning false

### DIFF
--- a/src/c/mip/mip_field.c
+++ b/src/c/mip/mip_field.c
@@ -71,6 +71,14 @@ uint8_t mip_field_payload_length(const mip_field_view* field)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+///@brief Returns the total length of the field including the header.
+///
+uint8_t mip_field_total_length(const mip_field_view* field)
+{
+    return MIP_FIELD_HEADER_LENGTH + mip_field_payload_length(field);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 ///@brief Returns the payload pointer for the field data.
 ///
 const uint8_t* mip_field_payload(const mip_field_view* field)

--- a/src/c/mip/mip_field.h
+++ b/src/c/mip/mip_field.h
@@ -71,6 +71,7 @@ void mip_field_init(mip_field_view* field, uint8_t descriptor_set, uint8_t field
 uint8_t mip_field_descriptor_set(const mip_field_view* field);
 uint8_t mip_field_field_descriptor(const mip_field_view* field);
 uint8_t mip_field_payload_length(const mip_field_view* field);
+uint8_t mip_field_total_length(const mip_field_view* field);
 const uint8_t* mip_field_payload(const mip_field_view* field);
 
 bool mip_field_is_valid(const mip_field_view* field);

--- a/src/c/mip/mip_interface.c
+++ b/src/c/mip/mip_interface.c
@@ -537,9 +537,12 @@ void mip_interface_update_time(mip_interface* device, mip_timestamp timestamp)
 ///@param packet    MIP Packet from the parser.
 ///@param timestamp Timestamp of the packet.
 ///
-void mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp)
+///@returns true
+///
+bool mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp)
 {
     mip_interface_input_packet_from_device(device, packet, timestamp);
+    return true;
 }
 
 

--- a/src/c/mip/mip_interface.h
+++ b/src/c/mip/mip_interface.h
@@ -76,7 +76,7 @@ void mip_interface_input_bytes_from_device(mip_interface* device, const uint8_t*
 void mip_interface_input_packet_from_device(mip_interface* device, const mip_packet_view* packet, mip_timestamp timestamp);
 void mip_interface_update_time(mip_interface* device, mip_timestamp timestamp);
 
-void mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp);
+bool mip_interface_parse_callback(void* device, const mip_packet_view* packet, mip_timestamp timestamp);
 
 //
 // Commands

--- a/src/c/mip/mip_parser.h
+++ b/src/c/mip/mip_parser.h
@@ -36,11 +36,16 @@ extern "C" {
 ///
 
 
+////////////////////////////////////////////////////////////////////////////////
 ///@brief Callback function which receives parsed MIP packets.
+///
 ///@param user A user-specified pointer which will be given the callback_object parameter which was previously passed to mip_parser_init.
 ///@param packet A pointer to the MIP packet. Do not store this pointer as it will be invalidated after the callback returns.
 ///@param timestamp The approximate time the packet was parsed.
-typedef void (*mip_packet_callback)(void* user, const mip_packet_view* packet, mip_timestamp timestamp);
+///
+///@return True if more packets should be parsed, or false to stop parsing.
+///
+typedef bool (*mip_packet_callback)(void* user, const mip_packet_view* packet, mip_timestamp timestamp);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -78,7 +83,7 @@ typedef struct mip_parser
 
 
 void mip_parser_init(mip_parser* parser, mip_packet_callback callback, void* callback_object, mip_timeout timeout);
-void mip_parser_parse(mip_parser* parser, const uint8_t* input_buffer, size_t input_length, mip_timestamp timestamp);
+size_t mip_parser_parse(mip_parser* parser, const uint8_t* input_buffer, size_t input_length, mip_timestamp timestamp);
 void mip_parser_flush(mip_parser* parser);
 
 void mip_parser_reset(mip_parser* parser);

--- a/src/cpp/mip/mip_field.hpp
+++ b/src/cpp/mip/mip_field.hpp
@@ -48,6 +48,8 @@ public:
     CompositeDescriptor descriptor() const { return {descriptorSet(), fieldDescriptor()}; }
     ///@copydoc mip::C::mip_field_payload_length
     uint8_t payloadLength() const { return C::mip_field_payload_length(this); }
+    ///@copydoc mip::C::mip_field_total_length
+    uint8_t totalLength() const { return C::mip_field_total_length(this); }
     ///@copydoc mip::C::mip_field_payload
     const uint8_t* payload() const { return C::mip_field_payload(this); }
 

--- a/src/cpp/mip/mip_parser.hpp
+++ b/src/cpp/mip/mip_parser.hpp
@@ -22,22 +22,37 @@ public:
     ///@copydoc mip::C::mip_parser_init
     Parser(C::mip_packet_callback callback, void* callbackObject, Timeout timeout) { C::mip_parser_init(this, callback, callbackObject, timeout); }
     ///@copydoc mip::C::mip_parser_init
-    Parser(void (*callback)(void*,const PacketView*,Timestamp), void* callbackObject, Timeout timeout) { C::mip_parser_init(this, (C::mip_packet_callback)callback, callbackObject, timeout); }
+    Parser(bool (*callback)(void*,const PacketView*,Timestamp), void* callbackObject, Timeout timeout) { C::mip_parser_init(this, (C::mip_packet_callback)callback, callbackObject, timeout); }
+    /// Construct without a callback.
+    explicit Parser(Timeout timeout) { C::mip_parser_init(this, nullptr, nullptr, timeout); }
 
-    Parser(Timeout timeout) { C::mip_parser_init(this, nullptr, nullptr, timeout); }
+    void setCallback(C::mip_packet_callback callback, void* callbackObject) { C::mip_parser_set_callback(this, callback, callbackObject); }
+
+    template<class Lambda>
+    void setCallback(Lambda lambda);
 
     template<class T, bool (T::*Callback)(const PacketView&, Timestamp)>
+    void setCallback(T& object);
+
+    template<class T, bool (*Callback)(T&, const PacketView&, Timestamp)>
     void setCallback(T& object);
 
     ///@copydoc mip::C::mip_parser_reset
     void reset() { C::mip_parser_reset(this); }
 
     ///@copydoc mip::C::mip_parser_parse
-    void parse(const uint8_t* inputBuffer, size_t inputCount, Timestamp timestamp) { return C::mip_parser_parse(this, inputBuffer, inputCount, timestamp); }
+    size_t parse(const uint8_t* inputBuffer, size_t inputCount, Timestamp timestamp) { return C::mip_parser_parse(this, inputBuffer, inputCount, timestamp); }
 
     ///@brief Parse packets from a buffer (span version).
     ///@copydetails mip::C::mip_parser_parse
-    void parse(microstrain::Span<const uint8_t> data, Timestamp timestamp) { return parse(data.data(), data.size(), timestamp); }
+    size_t parse(microstrain::Span<const uint8_t> data, Timestamp timestamp) { return parse(data.data(), data.size(), timestamp); }
+
+    ///@copydoc mip::C::mip_parser_flush
+    void flush() { C::mip_parser_flush(this); }
+
+    ///@copybrief mip::C::mip_parser_get_write_ptr
+    ///@returns a buffer into which data can be written.
+    microstrain::Span<uint8_t> getWritePtr() { uint8_t* ptr; size_t length = C::mip_parser_get_write_ptr(this, &ptr); return {ptr, length}; }
 
     ///@copydoc mip::C::mip_parser_timeout
     Timeout timeout() const { return C::mip_parser_timeout(this); }
@@ -45,6 +60,17 @@ public:
     void setTimeout(Timeout timeout) { return C::mip_parser_set_timeout(this, timeout); }
 };
 
+
+template<class FunctionOrLambda>
+void Parser::setCallback(FunctionOrLambda function)
+{
+    C::mip_packet_callback callback = [](void* obj, const C::mip_packet_view* packet, Timestamp timestamp)->bool
+    {
+        return *(static_cast<FunctionOrLambda*>(obj))( mip::PacketView(*packet), timestamp );
+    };
+
+    C::mip_parser_set_callback(this, callback, &function);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 ///@brief Initializes the MIP Parser
@@ -54,7 +80,7 @@ public:
 ///@code{.cpp}
 /// struct MyClass
 /// {
-///     void handlePacket(const PacketRef& packet, Timeout timeout);
+///     bool handlePacket(const PacketRef& packet, Timeout timeout);
 /// };
 /// MyClass myInstance;
 /// Parser parser<MyClass, &MyClass::handlePacket>(myInstance);
@@ -70,9 +96,39 @@ public:
 template<class T, bool (T::*Callback)(const PacketView&, Timestamp)>
 void Parser::setCallback(T& object)
 {
-    C::mip_packet_callback callback = [](void* obj, const C::mip_packet_view* pkt, Timestamp timestamp)->void
+    C::mip_packet_callback callback = +[](void* obj, const C::mip_packet_view* pkt, Timestamp timestamp)->bool
     {
-        (static_cast<T*>(obj)->*Callback)(PacketView(pkt), timestamp);
+        return (static_cast<T*>(obj)->*Callback)(PacketView(pkt), timestamp);
+    };
+
+    C::mip_parser_set_callback(this, callback, &object);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+///@brief Initializes the MIP Parser
+///
+/// This version allows binding a nonmember function instead of a C-style callback.
+/// Example:
+///@code{.cpp}
+/// struct MyData {};
+/// bool handlePacket(MyData& self, const PacketRef& packet, Timeout timeout);
+/// MyData myInstance;
+/// Parser parser<MyData, &handlePacket>(myInstance);
+///@endcode
+///
+///@tparam T Class type containing the member function to be called.
+///@tparam Callback A pointer to a nonmember function taking a T to be called when a
+///        packet is parsed.
+///
+///@param object
+///       Instance of T to call the callback.
+///
+template<class T, bool (*Callback)(T&, const PacketView&, Timestamp)>
+void Parser::setCallback(T& object)
+{
+    C::mip_packet_callback callback = +[](void* obj, const C::mip_packet_view* pkt, Timestamp timestamp)->bool
+    {
+        return (*Callback)(*static_cast<T*>(obj), PacketView(pkt), timestamp);
     };
 
     C::mip_parser_set_callback(this, callback, &object);


### PR DESCRIPTION
* Changed callback signature to return bool instead of void
* Changed mip_parser_parse to return the number of unprocessed bytes instead of void
* Fixed a bug where a timed-out packet could cause an infinite loop if the internal parser buffer was empty.
* Added some missing API functions.
